### PR TITLE
feat(party): add /seq p commands and improve invites

### DIFF
--- a/src/main/java/org/sequoia/seq/accessors/NotificationAccessor.java
+++ b/src/main/java/org/sequoia/seq/accessors/NotificationAccessor.java
@@ -20,27 +20,46 @@ public interface NotificationAccessor {
     String PILL_BG_FRONT = "";
 
     static @NotNull MutableComponent prefixComponent() {
-        MutableComponent prefix = Component.empty();
-        prefix.append(Component.literal(PILL_CORNER_LEFT).withStyle(ChatFormatting.DARK_PURPLE));
-
-        for (int i = 0; i < PREFIX_LABEL.length(); i++) {
-            String glyph = toWynncraftGlyph(PREFIX_LABEL.charAt(i));
-            prefix.append(Component.literal(PILL_BG_BACK).withStyle(ChatFormatting.DARK_PURPLE));
-            prefix.append(Component.literal(PILL_BG_FRONT + glyph).withStyle(ChatFormatting.WHITE));
-        }
-
-        prefix.append(Component.literal(PILL_CORNER_RIGHT).withStyle(ChatFormatting.DARK_PURPLE));
-        prefix.append(Component.literal(" "));
-        return prefix;
+        return wynnPill(PREFIX_LABEL, ChatFormatting.DARK_PURPLE, ChatFormatting.WHITE)
+                .append(Component.literal(" "));
     }
 
-    default void notify(String message) {
+    static @NotNull MutableComponent wynnPill(
+            String label,
+            ChatFormatting backgroundColor,
+            ChatFormatting foregroundColor) {
+        return wynnPill(label, backgroundColor, foregroundColor, null);
+    }
+
+    static @NotNull MutableComponent wynnPill(
+            String label,
+            ChatFormatting backgroundColor,
+            ChatFormatting foregroundColor,
+            ClickEvent clickEvent) {
+        MutableComponent pill = Component.empty();
+        pill.append(styledPillPart(PILL_CORNER_LEFT, backgroundColor, clickEvent));
+
+        for (int i = 0; i < label.length(); i++) {
+            String glyph = toWynncraftGlyph(label.charAt(i));
+            pill.append(styledPillPart(PILL_BG_BACK, backgroundColor, clickEvent));
+            pill.append(styledPillPart(PILL_BG_FRONT + glyph, foregroundColor, clickEvent));
+        }
+
+        pill.append(styledPillPart(PILL_CORNER_RIGHT, backgroundColor, clickEvent));
+        return pill;
+    }
+
+    static void notifyPlayer(String message) {
         Minecraft.getInstance().execute(() -> {
             LocalPlayer player = Minecraft.getInstance().player;
             if (player != null) {
                 player.displayClientMessage(prefixed(message), false);
             }
         });
+    }
+
+    default void notify(String message) {
+        notifyPlayer(message);
     }
 
     default void notifyClickable(String text, String url) {
@@ -65,6 +84,19 @@ public interface NotificationAccessor {
 
     static @NotNull Component prefixed(String message) {
         return prefixComponent().append(Component.literal(String.valueOf(message)).withStyle(ChatFormatting.GRAY));
+    }
+
+    private static MutableComponent styledPillPart(
+            String text,
+            ChatFormatting color,
+            ClickEvent clickEvent) {
+        return Component.literal(text).withStyle(style -> {
+            style = style.withColor(color);
+            if (clickEvent != null) {
+                style = style.withClickEvent(clickEvent);
+            }
+            return style;
+        });
     }
 
     private static String toWynncraftGlyph(char rawChar) {

--- a/src/main/java/org/sequoia/seq/accessors/NotificationAccessor.java
+++ b/src/main/java/org/sequoia/seq/accessors/NotificationAccessor.java
@@ -13,10 +13,25 @@ import java.net.URISyntaxException;
 
 public interface NotificationAccessor {
 
-    String PREFIX = "Sequoia » ";
+    String PREFIX_LABEL = "sequoia";
+    String PILL_CORNER_LEFT = "⁤";
+    String PILL_CORNER_RIGHT = "⁤";
+    String PILL_BG_BACK = "";
+    String PILL_BG_FRONT = "";
 
     static @NotNull MutableComponent prefixComponent() {
-        return Component.literal(PREFIX).withStyle(ChatFormatting.DARK_PURPLE);
+        MutableComponent prefix = Component.empty();
+        prefix.append(Component.literal(PILL_CORNER_LEFT).withStyle(ChatFormatting.DARK_PURPLE));
+
+        for (int i = 0; i < PREFIX_LABEL.length(); i++) {
+            String glyph = toWynncraftGlyph(PREFIX_LABEL.charAt(i));
+            prefix.append(Component.literal(PILL_BG_BACK).withStyle(ChatFormatting.DARK_PURPLE));
+            prefix.append(Component.literal(PILL_BG_FRONT + glyph).withStyle(ChatFormatting.WHITE));
+        }
+
+        prefix.append(Component.literal(PILL_CORNER_RIGHT).withStyle(ChatFormatting.DARK_PURPLE));
+        prefix.append(Component.literal(" "));
+        return prefix;
     }
 
     default void notify(String message) {
@@ -50,5 +65,49 @@ public interface NotificationAccessor {
 
     static @NotNull Component prefixed(String message) {
         return prefixComponent().append(Component.literal(String.valueOf(message)).withStyle(ChatFormatting.GRAY));
+    }
+
+    private static String toWynncraftGlyph(char rawChar) {
+        char ch = Character.toLowerCase(rawChar);
+        return switch (ch) {
+            case 'a' -> "";
+            case 'b' -> "";
+            case 'c' -> "";
+            case 'd' -> "";
+            case 'e' -> "";
+            case 'f' -> "";
+            case 'g' -> "";
+            case 'h' -> "";
+            case 'i' -> "";
+            case 'j' -> "";
+            case 'k' -> "";
+            case 'l' -> "";
+            case 'm' -> "";
+            case 'n' -> "";
+            case 'o' -> "";
+            case 'p' -> "";
+            case 'q' -> "";
+            case 'r' -> "";
+            case 's' -> "";
+            case 't' -> "";
+            case 'u' -> "";
+            case 'v' -> "";
+            case 'w' -> "";
+            case 'x' -> "";
+            case 'y' -> "";
+            case 'z' -> "";
+            case '0' -> "";
+            case '1' -> "";
+            case '2' -> "";
+            case '3' -> "";
+            case '4' -> "";
+            case '5' -> "";
+            case '6' -> "";
+            case '7' -> "";
+            case '8' -> "";
+            case '9' -> "";
+            case ' ' -> " ";
+            default -> String.valueOf(rawChar);
+        };
     }
 }

--- a/src/main/java/org/sequoia/seq/command/SeqCommand.java
+++ b/src/main/java/org/sequoia/seq/command/SeqCommand.java
@@ -1,18 +1,37 @@
 package org.sequoia.seq.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.LongArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.message.v1.ClientSendMessageEvents;
 import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.SharedSuggestionProvider;
 import org.sequoia.seq.accessors.NotificationAccessor;
 import org.sequoia.seq.client.SeqClient;
+import org.sequoia.seq.managers.PartyFinderManager;
+import org.sequoia.seq.managers.PartyListing;
+import org.sequoia.seq.model.Activity;
+import org.sequoia.seq.model.Listing;
 import org.sequoia.seq.model.PartyRole;
 import org.sequoia.seq.network.ConnectionManager;
 import org.sequoia.seq.ui.PartyFinderScreen;
+import org.sequoia.seq.utils.PlayerNameCache;
 
 public class SeqCommand {
+
+        private static final List<String> ROLE_SUGGESTIONS = List.of("dps", "healer", "tank");
 
         public static void register() {
                 ClientCommandRegistrationCallback.EVENT.register(SeqCommand::registerCommands);
@@ -45,27 +64,22 @@ public class SeqCommand {
                                 .then(ClientCommandManager.literal("connected")
                                                 .executes(ctx -> {
                                                         if (!ConnectionManager.isConnected()) {
-                                                                ctx.getSource().sendFeedback(
-                                                                                NotificationAccessor.prefixed(
-                                                                                                "Not connected. Use /seq connect first."));
+                                                                sendFeedback(
+                                                                                ctx.getSource(),
+                                                                                "Not connected. Use /seq connect first.");
                                                                 return 0;
                                                         }
                                                         ConnectionManager.getInstance().requestConnectedUsers(users -> {
                                                                 if (users.isEmpty()) {
-                                                                        ctx.getSource().sendFeedback(
-                                                                                        NotificationAccessor.prefixed(
-                                                                                                        "No users connected."));
-                                                                } else {
-                                                                        ctx.getSource().sendFeedback(
-                                                                                        NotificationAccessor.prefixed(
-                                                                                                        "Connected users ("
-                                                                                                                        + users.size()
-                                                                                                                        + "):"));
-                                                                        for (String user : users) {
-                                                                                ctx.getSource().sendFeedback(
-                                                                                                NotificationAccessor
-                                                                                                                .prefixed("• " + user));
-                                                                        }
+                                                                        sendFeedback(ctx.getSource(), "No users connected.");
+                                                                        return;
+                                                                }
+
+                                                                sendFeedback(
+                                                                                ctx.getSource(),
+                                                                                "Connected users (" + users.size() + "):");
+                                                                for (String user : users) {
+                                                                        sendFeedback(ctx.getSource(), "• " + user);
                                                                 }
                                                         });
                                                         return 1;
@@ -77,34 +91,409 @@ public class SeqCommand {
                                                         boolean hasToken = token != null && !token.isBlank();
                                                         String uptime = ConnectionManager.getInstance()
                                                                         .getUptimeString();
-                                                        ctx.getSource().sendFeedback(NotificationAccessor.prefixed(
+                                                        sendFeedback(
+                                                                        ctx.getSource(),
                                                                         "Connected: " + connected
                                                                                         + " | Token: "
                                                                                         + (hasToken ? "present"
                                                                                                         : "none")
                                                                                         + (uptime != null
                                                                                                         ? " | Uptime: " + uptime
-                                                                                                        : "")));
+                                                                                                        : ""));
                                                         return 1;
                                                 }))
                                 .then(ClientCommandManager.literal("logout")
                                                 .executes(ctx -> {
                                                         ConnectionManager.getInstance().disconnect();
                                                         SeqClient.getConfigManager().clearToken();
-                                                        ctx.getSource().sendFeedback(
-                                                                        NotificationAccessor.prefixed(
-                                                                                        "Logged out and token cleared."));
+                                                        sendFeedback(ctx.getSource(), "Logged out and token cleared.");
                                                         return 1;
                                                 }))
-                                .then(ClientCommandManager.literal("party")
-                                                .executes(ctx -> {
-                                                        SeqClient.mc.execute(() -> SeqClient.mc
-                                                                        .setScreen(new PartyFinderScreen(
-                                                                                        SeqClient.mc.screen)));
-                                                        return 1;
-                                                }));
+                                .then(buildPartyCommand("party"))
+                                .then(buildPartyCommand("p"));
 
                 dispatcher.register(root);
+        }
+
+        private static LiteralArgumentBuilder<FabricClientCommandSource> buildPartyCommand(String literalName) {
+                return ClientCommandManager.literal(literalName)
+                                .executes(ctx -> openPartyScreen())
+                                .then(ClientCommandManager.literal("list")
+                                                .executes(SeqCommand::runPartyList))
+                                .then(ClientCommandManager.literal("status")
+                                                .executes(SeqCommand::runPartyStatus))
+                                .then(ClientCommandManager.literal("create")
+                                                .then(ClientCommandManager.argument(
+                                                                "activities",
+                                                                StringArgumentType.greedyString())
+                                                                .suggests(SeqCommand::suggestActivities)
+                                                                .executes(SeqCommand::runPartyCreate)))
+                                .then(ClientCommandManager.literal("update")
+                                                .then(ClientCommandManager.argument(
+                                                                "activities",
+                                                                StringArgumentType.greedyString())
+                                                                .suggests(SeqCommand::suggestActivities)
+                                                                .executes(SeqCommand::runPartyUpdate)))
+                                .then(ClientCommandManager.literal("join")
+                                                .then(ClientCommandManager.argument(
+                                                                "listingId",
+                                                                LongArgumentType.longArg(1))
+                                                                .executes(ctx -> runPartyJoin(ctx, PartyRole.DPS))
+                                                                .then(ClientCommandManager.argument(
+                                                                                "role",
+                                                                                StringArgumentType.word())
+                                                                                .suggests(SeqCommand::suggestRoles)
+                                                                                .executes(SeqCommand::runPartyJoinWithRole))))
+                                .then(ClientCommandManager.literal("leave")
+                                                .executes(ctx -> relayCommandResult(
+                                                                ctx,
+                                                                SeqClient.getPartyFinderManager()
+                                                                                .leavePartyFromCommand())))
+                                .then(ClientCommandManager.literal("invite")
+                                                .then(ClientCommandManager.argument(
+                                                                "username",
+                                                                StringArgumentType.word())
+                                                                .executes(SeqCommand::runPartyInvite)))
+                                .then(ClientCommandManager.literal("reserve")
+                                                .then(ClientCommandManager.argument(
+                                                                "count",
+                                                                IntegerArgumentType.integer(0))
+                                                                .executes(SeqCommand::runPartyReserve)))
+                                .then(ClientCommandManager.literal("open")
+                                                .executes(ctx -> relayCommandResult(
+                                                                ctx,
+                                                                SeqClient.getPartyFinderManager()
+                                                                                .reopenPartyFromCommand())))
+                                .then(ClientCommandManager.literal("close")
+                                                .executes(ctx -> relayCommandResult(
+                                                                ctx,
+                                                                SeqClient.getPartyFinderManager()
+                                                                                .closePartyFromCommand())))
+                                .then(ClientCommandManager.literal("disband")
+                                                .executes(ctx -> relayCommandResult(
+                                                                ctx,
+                                                                SeqClient.getPartyFinderManager()
+                                                                                .disbandPartyFromCommand())))
+                                .then(ClientCommandManager.literal("role")
+                                                .then(ClientCommandManager.argument(
+                                                                "role",
+                                                                StringArgumentType.word())
+                                                                .suggests(SeqCommand::suggestRoles)
+                                                                .executes(SeqCommand::runPartyRole)))
+                                .then(ClientCommandManager.literal("kick")
+                                                .then(ClientCommandManager.argument(
+                                                                "username",
+                                                                StringArgumentType.word())
+                                                                .executes(SeqCommand::runPartyKick)))
+                                .then(ClientCommandManager.literal("promote")
+                                                .then(ClientCommandManager.argument(
+                                                                "username",
+                                                                StringArgumentType.word())
+                                                                .executes(SeqCommand::runPartyPromote)))
+                                .then(ClientCommandManager.literal("game")
+                                                .then(ClientCommandManager.literal("create")
+                                                                .executes(ctx -> relayCommandResult(
+                                                                                ctx,
+                                                                                SeqClient.getPartyFinderManager()
+                                                                                                .createGamePartyFromCommand())))
+                                                .then(ClientCommandManager.literal("invite")
+                                                                .then(ClientCommandManager.argument(
+                                                                                "username",
+                                                                                StringArgumentType.word())
+                                                                                .executes(SeqCommand::runGameInvite)))
+                                                .then(ClientCommandManager.literal("invite-all")
+                                                                .executes(ctx -> relayCommandResult(
+                                                                                ctx,
+                                                                                SeqClient.getPartyFinderManager()
+                                                                                                .inviteAllCurrentMembersFromCommand()))));
+        }
+
+        private static int openPartyScreen() {
+                SeqClient.mc.execute(() -> SeqClient.mc.setScreen(new PartyFinderScreen(SeqClient.mc.screen)));
+                return 1;
+        }
+
+        private static int runPartyList(CommandContext<FabricClientCommandSource> ctx) {
+                FabricClientCommandSource source = ctx.getSource();
+                PartyFinderManager manager = SeqClient.getPartyFinderManager();
+                manager.refreshListingsForCommand().whenComplete((result, error) -> {
+                        if (error != null) {
+                                sendFeedback(source, "Unexpected error while loading party listings.");
+                                return;
+                        }
+                        if (!result.success()) {
+                                sendFeedback(source, result.message());
+                                return;
+                        }
+
+                        List<Listing> listings = result.data();
+                        if (listings == null || listings.isEmpty()) {
+                                sendFeedback(source, "No Sequoia party listings found.");
+                                return;
+                        }
+
+                        sendFeedback(source, "Party listings (" + listings.size() + "):");
+                        Listing currentListing = manager.getCurrentListing();
+                        for (Listing listing : listings) {
+                                boolean isCurrent = currentListing != null && currentListing.id() == listing.id();
+                                sendFeedback(source, formatListingSummary(listing, isCurrent));
+                        }
+                });
+                return 1;
+        }
+
+        private static int runPartyStatus(CommandContext<FabricClientCommandSource> ctx) {
+                FabricClientCommandSource source = ctx.getSource();
+                PartyFinderManager manager = SeqClient.getPartyFinderManager();
+                manager.refreshListingsForCommand().whenComplete((result, error) -> {
+                        if (error != null) {
+                                sendFeedback(source, "Unexpected error while loading party status.");
+                                return;
+                        }
+                        if (!result.success()) {
+                                sendFeedback(source, result.message());
+                                return;
+                        }
+
+                        Listing currentListing = manager.getCurrentListing();
+                        if (currentListing == null) {
+                                sendFeedback(source, "You are not currently in a Sequoia party.");
+                                return;
+                        }
+
+                        sendFeedback(source, "Current party: " + formatListingSummary(currentListing, true));
+                        sendFeedback(
+                                        source,
+                                        manager.isPartyLeader()
+                                                        ? "You are the party leader."
+                                                        : "You are a party member.");
+                });
+                return 1;
+        }
+
+        private static int runPartyCreate(CommandContext<FabricClientCommandSource> ctx) {
+                List<String> activities = parseActivitiesInput(
+                                StringArgumentType.getString(ctx, "activities"));
+                if (activities.isEmpty()) {
+                        sendFeedback(ctx.getSource(), "Provide at least one activity.");
+                        return 0;
+                }
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().createPartyFromCommand(activities));
+        }
+
+        private static int runPartyUpdate(CommandContext<FabricClientCommandSource> ctx) {
+                List<String> activities = parseActivitiesInput(
+                                StringArgumentType.getString(ctx, "activities"));
+                if (activities.isEmpty()) {
+                        sendFeedback(ctx.getSource(), "Provide at least one activity.");
+                        return 0;
+                }
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().updatePartyFromCommand(activities));
+        }
+
+        private static int runPartyJoin(CommandContext<FabricClientCommandSource> ctx, PartyRole role) {
+                long listingId = LongArgumentType.getLong(ctx, "listingId");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().joinPartyFromCommand(listingId, role));
+        }
+
+        private static int runPartyJoinWithRole(CommandContext<FabricClientCommandSource> ctx) {
+                PartyRole role = parseRole(StringArgumentType.getString(ctx, "role"));
+                if (role == null) {
+                        sendFeedback(ctx.getSource(), "Role must be one of: DPS, Healer, Tank.");
+                        return 0;
+                }
+                return runPartyJoin(ctx, role);
+        }
+
+        private static int runPartyInvite(CommandContext<FabricClientCommandSource> ctx) {
+                String username = StringArgumentType.getString(ctx, "username");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().createInviteFromCommand(username));
+        }
+
+        private static int runPartyReserve(CommandContext<FabricClientCommandSource> ctx) {
+                int count = IntegerArgumentType.getInteger(ctx, "count");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().setReservedSlotTargetFromCommand(count));
+        }
+
+        private static int runPartyRole(CommandContext<FabricClientCommandSource> ctx) {
+                PartyRole role = parseRole(StringArgumentType.getString(ctx, "role"));
+                if (role == null) {
+                        sendFeedback(ctx.getSource(), "Role must be one of: DPS, Healer, Tank.");
+                        return 0;
+                }
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().changeRoleFromCommand(role));
+        }
+
+        private static int runPartyKick(CommandContext<FabricClientCommandSource> ctx) {
+                String username = StringArgumentType.getString(ctx, "username");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().kickMemberFromCommand(username));
+        }
+
+        private static int runPartyPromote(CommandContext<FabricClientCommandSource> ctx) {
+                String username = StringArgumentType.getString(ctx, "username");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().promoteMemberFromCommand(username));
+        }
+
+        private static int runGameInvite(CommandContext<FabricClientCommandSource> ctx) {
+                String username = StringArgumentType.getString(ctx, "username");
+                return relayCommandResult(
+                                ctx,
+                                SeqClient.getPartyFinderManager().inviteGamePlayerFromCommand(username));
+        }
+
+        private static <T> int relayCommandResult(
+                        CommandContext<FabricClientCommandSource> ctx,
+                        CompletableFuture<PartyFinderManager.CommandResult<T>> future) {
+                FabricClientCommandSource source = ctx.getSource();
+                future.whenComplete((result, error) -> {
+                        if (error != null) {
+                                sendFeedback(source, "Unexpected command failure.");
+                                return;
+                        }
+                        if (result != null && result.message() != null && !result.message().isBlank()) {
+                                sendFeedback(source, result.message());
+                        }
+                });
+                return 1;
+        }
+
+        private static CompletableFuture<Suggestions> suggestRoles(
+                        CommandContext<FabricClientCommandSource> ctx,
+                        SuggestionsBuilder builder) {
+                return SharedSuggestionProvider.suggest(ROLE_SUGGESTIONS, builder);
+        }
+
+        private static CompletableFuture<Suggestions> suggestActivities(
+                        CommandContext<FabricClientCommandSource> ctx,
+                        SuggestionsBuilder builder) {
+                String remaining = builder.getRemaining();
+                int lastCommaIndex = remaining.lastIndexOf(',');
+                int segmentStart = lastCommaIndex >= 0 ? lastCommaIndex + 1 : 0;
+                while (segmentStart < remaining.length() && Character.isWhitespace(remaining.charAt(segmentStart))) {
+                        segmentStart++;
+                }
+
+                String segment = remaining.substring(segmentStart);
+                if (!segment.isEmpty() && (segment.charAt(0) == '"' || segment.charAt(0) == '\'')) {
+                        segment = segment.substring(1);
+                }
+
+                SuggestionsBuilder segmentBuilder = builder.createOffset(builder.getStart() + segmentStart);
+                String loweredSegment = segment.toLowerCase(Locale.ROOT);
+                List<String> matches = PartyListing.activityCommandAliases()
+                                .stream()
+                                .filter(alias -> alias.toLowerCase(Locale.ROOT).startsWith(loweredSegment))
+                                .toList();
+                return SharedSuggestionProvider.suggest(matches, segmentBuilder);
+        }
+
+        private static List<String> parseActivitiesInput(String rawActivities) {
+                List<String> activities = new ArrayList<>();
+                if (rawActivities == null || rawActivities.isBlank()) {
+                        return activities;
+                }
+
+                StringBuilder current = new StringBuilder();
+                char activeQuote = 0;
+                for (int i = 0; i < rawActivities.length(); i++) {
+                        char ch = rawActivities.charAt(i);
+                        if ((ch == '"' || ch == '\'') && (activeQuote == 0 || activeQuote == ch)) {
+                                activeQuote = activeQuote == 0 ? ch : 0;
+                                continue;
+                        }
+                        if (ch == ',' && activeQuote == 0) {
+                                addActivityToken(activities, current.toString());
+                                current.setLength(0);
+                                continue;
+                        }
+                        current.append(ch);
+                }
+                addActivityToken(activities, current.toString());
+                return activities;
+        }
+
+        private static void addActivityToken(List<String> activities, String rawToken) {
+                if (rawToken == null) {
+                        return;
+                }
+                String normalized = rawToken.trim();
+                if (normalized.length() >= 2
+                                && ((normalized.startsWith("\"") && normalized.endsWith("\""))
+                                                || (normalized.startsWith("'") && normalized.endsWith("'")))) {
+                        normalized = normalized.substring(1, normalized.length() - 1).trim();
+                }
+                if (!normalized.isEmpty()) {
+                        activities.add(normalized);
+                }
+        }
+
+        private static PartyRole parseRole(String rawRole) {
+                        if (rawRole == null) {
+                                return null;
+                        }
+                        return switch (rawRole.trim().toLowerCase(Locale.ROOT)) {
+                                case "dps" -> PartyRole.DPS;
+                                case "healer" -> PartyRole.HEALER;
+                                case "tank" -> PartyRole.TANK;
+                                default -> null;
+                        };
+        }
+
+        private static String formatListingSummary(Listing listing, boolean isCurrent) {
+                String prefix = isCurrent ? "* " : "• ";
+                String activities = listing.resolvedActivities()
+                                .stream()
+                                .map(Activity::name)
+                                .map(PartyListing::backendNameToDisplayName)
+                                .reduce((left, right) -> left + ", " + right)
+                                .orElse("Unknown Activity");
+                String leaderName = PlayerNameCache.resolve(listing.leaderUUID());
+                boolean leaderResolvable = leaderName != null
+                                && !leaderName.isBlank()
+                                && !"Loading...".equalsIgnoreCase(leaderName)
+                                && !"Unknown".equalsIgnoreCase(leaderName);
+                String leaderSegment = leaderResolvable ? " | Leader: " + leaderName : "";
+
+                return prefix + "#" + listing.id()
+                                + " | "
+                                + activities
+                                + " | "
+                                + formatEnumLabel(listing.mode().name())
+                                + " | "
+                                + listing.occupiedSlotCount()
+                                + "/"
+                                + listing.maxPartySize()
+                                + " | "
+                                + formatEnumLabel(listing.status().name())
+                                + leaderSegment;
+        }
+
+        private static String formatEnumLabel(String raw) {
+                if (raw == null || raw.isBlank()) {
+                        return "";
+                }
+                String lower = raw.toLowerCase(Locale.ROOT);
+                return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+        }
+
+        private static void sendFeedback(FabricClientCommandSource source, String message) {
+                SeqClient.mc.execute(() -> source.sendFeedback(NotificationAccessor.prefixed(message)));
         }
 
         private static int runInternalJoinInvite(

--- a/src/main/java/org/sequoia/seq/command/SeqCommand.java
+++ b/src/main/java/org/sequoia/seq/command/SeqCommand.java
@@ -522,18 +522,26 @@ public class SeqCommand {
                         long listingId,
                         String inviteToken) {
                 if (inviteToken == null || inviteToken.isBlank()) {
+                        NotificationAccessor.notifyPlayer("Invite token missing.");
                         return 0;
                 }
 
+                NotificationAccessor.notifyPlayer("Joining party finder invite...");
                 SeqClient.getPartyFinderManager().joinPartyWithInviteToken(
                                 listingId,
                                 PartyRole.DPS,
-                                inviteToken);
+                                inviteToken)
+                                .thenAccept(listing -> {
+                                        if (listing != null) {
+                                                NotificationAccessor.notifyPlayer("Joined party finder party.");
+                                        }
+                                });
                 return 1;
         }
 
         private static int runInternalDenyInvite(
                         long listingId) {
+                NotificationAccessor.notifyPlayer("Denied party finder invite.");
                 return 1;
         }
 }

--- a/src/main/java/org/sequoia/seq/command/SeqCommand.java
+++ b/src/main/java/org/sequoia/seq/command/SeqCommand.java
@@ -15,7 +15,6 @@ import java.util.concurrent.CompletableFuture;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.fabricmc.fabric.api.client.message.v1.ClientSendMessageEvents;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.SharedSuggestionProvider;
 import org.sequoia.seq.accessors.NotificationAccessor;
@@ -35,7 +34,6 @@ public class SeqCommand {
 
         public static void register() {
                 ClientCommandRegistrationCallback.EVENT.register(SeqCommand::registerCommands);
-                ClientSendMessageEvents.ALLOW_COMMAND.register(SeqCommand::onOutgoingCommand);
         }
 
         private static void registerCommands(
@@ -113,6 +111,30 @@ public class SeqCommand {
                                 .then(buildPartyCommand("p"));
 
                 dispatcher.register(root);
+                dispatcher.register(buildInternalInviteCommand());
+        }
+
+        private static LiteralArgumentBuilder<FabricClientCommandSource> buildInternalInviteCommand() {
+                return ClientCommandManager.literal("_seqinvite")
+                                .then(ClientCommandManager.literal("join")
+                                                .then(ClientCommandManager.argument(
+                                                                "listingId",
+                                                                LongArgumentType.longArg(1))
+                                                                .then(ClientCommandManager.argument(
+                                                                                "inviteToken",
+                                                                                StringArgumentType.string())
+                                                                                .executes(ctx -> runInternalJoinInvite(
+                                                                                                LongArgumentType.getLong(ctx,
+                                                                                                                "listingId"),
+                                                                                                StringArgumentType.getString(ctx,
+                                                                                                                "inviteToken"))))))
+                                .then(ClientCommandManager.literal("deny")
+                                                .then(ClientCommandManager.argument(
+                                                                "listingId",
+                                                                LongArgumentType.longArg(1))
+                                                                .executes(ctx -> runInternalDenyInvite(
+                                                                                LongArgumentType.getLong(ctx,
+                                                                                                "listingId")))));
         }
 
         private static LiteralArgumentBuilder<FabricClientCommandSource> buildPartyCommand(String literalName) {
@@ -513,60 +535,5 @@ public class SeqCommand {
         private static int runInternalDenyInvite(
                         long listingId) {
                 return 1;
-        }
-
-        private static boolean onOutgoingCommand(String command) {
-                String raw = command == null ? "" : command.trim();
-                if (raw.isEmpty()) {
-                        return true;
-                }
-                if (raw.charAt(0) == '/') {
-                        raw = raw.substring(1).trim();
-                }
-                if (!raw.startsWith("_seqinvite")) {
-                        return true;
-                }
-
-                String[] parts = raw.split("\\s+", 4);
-                if (parts.length < 3) {
-                        return false;
-                }
-
-                String action = parts[1];
-                long listingId;
-                try {
-                        listingId = Long.parseLong(parts[2]);
-                } catch (NumberFormatException ignored) {
-                        return false;
-                }
-
-                if ("join".equalsIgnoreCase(action)) {
-                        if (parts.length < 4) {
-                                return false;
-                        }
-                        String inviteToken = unquoteCommandValue(parts[3]);
-                        runInternalJoinInvite(listingId, inviteToken);
-                        return false;
-                }
-
-                if ("deny".equalsIgnoreCase(action)) {
-                        runInternalDenyInvite(listingId);
-                        return false;
-                }
-
-                return false;
-        }
-
-        private static String unquoteCommandValue(String rawValue) {
-                if (rawValue == null) {
-                        return "";
-                }
-                String value = rawValue.trim();
-                if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
-                        value = value.substring(1, value.length() - 1)
-                                        .replace("\\\"", "\"")
-                                        .replace("\\\\", "\\");
-                }
-                return value;
         }
 }

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -891,9 +891,9 @@ public class PartyFinderManager implements NotificationAccessor {
             ClickEvent joinClickEvent = new ClickEvent.RunCommand(joinCommand);
             ClickEvent denyClickEvent = new ClickEvent.RunCommand(denyCommand);
 
-            MutableComponent fullMessage = NotificationAccessor.prefixComponent()
-                    .append(Component.literal(String.valueOf(message)).withStyle(ChatFormatting.GRAY))
-                    .append(Component.literal(" "))
+            MutableComponent inviteMessage = NotificationAccessor.prefixComponent()
+                    .append(Component.literal(String.valueOf(message)).withStyle(ChatFormatting.GRAY));
+            MutableComponent actionMessage = Component.empty()
                     .append(NotificationAccessor.wynnPill(
                             "join",
                             ChatFormatting.GREEN,
@@ -912,7 +912,8 @@ public class PartyFinderManager implements NotificationAccessor {
                     player.getName().getString(),
                     joinCommand,
                     denyCommand);
-            player.displayClientMessage(fullMessage, false);
+            player.displayClientMessage(inviteMessage, false);
+            player.displayClientMessage(actionMessage, false);
         });
     }
 

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -51,6 +51,14 @@ public class PartyFinderManager implements NotificationAccessor {
     private int cachedVersion = -1;
     private volatile String latestPartyError;
 
+    public record InviteAllResult(
+            boolean success,
+            boolean sentAny,
+            int sentCount,
+            int skippedCount,
+            String message) {
+    }
+
     public PartyFinderManager() {
         SeqClient.LOGGER.info("[PartyFinderWS] Registering party finder websocket handlers");
         // Register for real-time WS updates
@@ -766,6 +774,107 @@ public class PartyFinderManager implements NotificationAccessor {
                 });
     }
 
+    public InviteAllResult inviteAllCurrentMembers() {
+        if (currentListing == null) {
+            return finishInviteAll(
+                    false,
+                    false,
+                    0,
+                    0,
+                    "Invite all: no active party found.");
+        }
+
+        if (!isPartyLeader()) {
+            return finishInviteAll(
+                    false,
+                    false,
+                    0,
+                    0,
+                    "Invite all: only the party leader can use this.");
+        }
+
+        var player = SeqClient.mc.player;
+        if (player == null || player.connection == null) {
+            return finishInviteAll(
+                    false,
+                    false,
+                    0,
+                    0,
+                    "Invite all: client connection unavailable.");
+        }
+
+        List<Member> members = currentListing.members();
+        if (members == null || members.isEmpty()) {
+            return finishInviteAll(
+                    true,
+                    false,
+                    0,
+                    0,
+                    "Invite all: no valid party members to invite.");
+        }
+
+        String myUUID = getLocalPlayerUUID();
+        List<String> targets = new ArrayList<>();
+        Set<String> seenTargets = new LinkedHashSet<>();
+        int skippedCount = 0;
+
+        for (Member member : members) {
+            if (member == null) {
+                skippedCount++;
+                continue;
+            }
+
+            String memberUUID = member.playerUUID();
+            if (memberUUID == null || memberUUID.isBlank()) {
+                skippedCount++;
+                continue;
+            }
+
+            if (uuidEquals(myUUID, memberUUID)) {
+                skippedCount++;
+                continue;
+            }
+
+            String username = PlayerNameCache.resolve(memberUUID);
+            if (username == null
+                    || username.isBlank()
+                    || "Loading...".equalsIgnoreCase(username)
+                    || "Unknown".equalsIgnoreCase(username)
+                    || !username.matches("[A-Za-z0-9_]{3,16}")) {
+                skippedCount++;
+                continue;
+            }
+
+            String normalizedUsername = username.toLowerCase(Locale.ROOT);
+            if (!seenTargets.add(normalizedUsername)) {
+                skippedCount++;
+                continue;
+            }
+
+            targets.add(username);
+        }
+
+        if (targets.isEmpty()) {
+            return finishInviteAll(
+                    true,
+                    false,
+                    0,
+                    skippedCount,
+                    formatInviteAllMessage(0, skippedCount));
+        }
+
+        for (String username : targets) {
+            player.connection.sendCommand("pa " + username);
+        }
+
+        return finishInviteAll(
+                true,
+                true,
+                targets.size(),
+                skippedCount,
+                formatInviteAllMessage(targets.size(), skippedCount));
+    }
+
     /** Leaves the current party (no-arg overload). */
     public void leaveParty() {
         if (currentListing != null) {
@@ -1065,6 +1174,31 @@ public class PartyFinderManager implements NotificationAccessor {
         String errorMessage = extractUserFriendlyApiError(throwable, fallbackMessage);
         SeqClient.LOGGER.warn("{}: {}", logMessage, errorMessage);
         pushUiError(errorMessage);
+    }
+
+    private InviteAllResult finishInviteAll(
+            boolean success,
+            boolean sentAny,
+            int sentCount,
+            int skippedCount,
+            String message) {
+        notify(message);
+        return new InviteAllResult(success, sentAny, sentCount, skippedCount, message);
+    }
+
+    private static String formatInviteAllMessage(int sentCount, int skippedCount) {
+        if (sentCount <= 0) {
+            if (skippedCount > 0) {
+                return "Invite all: no valid party members to invite. Skipped " + skippedCount + ".";
+            }
+            return "Invite all: no valid party members to invite.";
+        }
+
+        String inviteWord = sentCount == 1 ? "invite" : "invites";
+        if (skippedCount > 0) {
+            return "Invite all: sent " + sentCount + " " + inviteWord + ". Skipped " + skippedCount + ".";
+        }
+        return "Invite all: sent " + sentCount + " " + inviteWord + ".";
     }
 
     private void sendGameDirectMessage(UUID targetUUID, String message) {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -33,6 +33,8 @@ public class PartyFinderManager implements NotificationAccessor {
     private static final long INVITE_NAME_LOOKUP_TIMEOUT_SECONDS = 3L;
     private static final String GAME_PARTY_CREATE_COMMAND = "party create";
     private static final String GAME_PARTY_INVITE_PREFIX = "party invite ";
+    private static final String GAME_PARTY_KICK_PREFIX = "pa kick ";
+    private static final String GAME_PARTY_PROMOTE_PREFIX = "pa promote ";
 
     @Getter
     private final List<Activity> activities = new CopyOnWriteArrayList<>();
@@ -1027,6 +1029,7 @@ public class PartyFinderManager implements NotificationAccessor {
             transferLeadership(party.id, targetUUID)
                     .thenAccept(listing -> {
                         if (listing != null) {
+                            sendGamePartyCommandForUuid(targetUUID, GAME_PARTY_PROMOTE_PREFIX);
                             sendGameDirectMessage(
                                     targetUUID,
                                     "You were promoted to party leader.");
@@ -1057,6 +1060,7 @@ public class PartyFinderManager implements NotificationAccessor {
             kickMember(party.id, targetUUID)
                     .thenAccept(listing -> {
                         if (listing != null) {
+                            sendGamePartyCommandForUuid(targetUUID, GAME_PARTY_KICK_PREFIX);
                             sendGameDirectMessage(
                                     targetUUID,
                                     "You were kicked from the party.");
@@ -1890,6 +1894,34 @@ public class PartyFinderManager implements NotificationAccessor {
         }
         SeqClient.mc.player.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + normalizedUsername);
         return CommandResult.success("Sent Wynn party invite to " + normalizedUsername + ".", null);
+    }
+
+    private void sendGamePartyCommandForUuid(UUID targetUUID, String commandPrefix) {
+        if (targetUUID == null || commandPrefix == null || commandPrefix.isBlank()) {
+            return;
+        }
+
+        PlayerNameCache.resolveAsync(targetUUID.toString())
+                .completeOnTimeout(null, INVITE_NAME_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .thenAccept(resolvedName -> {
+                    if (resolvedName == null
+                            || resolvedName.isBlank()
+                            || "Loading...".equalsIgnoreCase(resolvedName)
+                            || "Unknown".equalsIgnoreCase(resolvedName)
+                            || !resolvedName.matches("[A-Za-z0-9_]{3,16}")) {
+                        SeqClient.LOGGER.warn("Skipping party command '{}' for unresolved UUID {}", commandPrefix,
+                                targetUUID);
+                        return;
+                    }
+
+                    SeqClient.mc.execute(() -> {
+                        var player = SeqClient.mc.player;
+                        if (player == null || player.connection == null) {
+                            return;
+                        }
+                        player.connection.sendCommand(commandPrefix + resolvedName);
+                    });
+                });
     }
 
     private static String validateUsername(String username, boolean rejectSelf) {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -6,6 +6,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import net.minecraft.ChatFormatting;
@@ -27,6 +29,8 @@ public class PartyFinderManager implements NotificationAccessor {
                     Instant.class,
                     (JsonDeserializer<Instant>) (json, type, ctx) -> Instant.parse(json.getAsString()))
             .create();
+    private static final String GAME_PARTY_CREATE_COMMAND = "party create";
+    private static final String GAME_PARTY_INVITE_PREFIX = "party invite ";
 
     @Getter
     private final List<Activity> activities = new CopyOnWriteArrayList<>();
@@ -57,6 +61,28 @@ public class PartyFinderManager implements NotificationAccessor {
             int sentCount,
             int skippedCount,
             String message) {
+    }
+
+    public record CommandResult<T>(boolean success, String message, T data) {
+        public static <T> CommandResult<T> success(String message, T data) {
+            return new CommandResult<>(true, message, data);
+        }
+
+        public static <T> CommandResult<T> failure(String message) {
+            return new CommandResult<>(false, message, null);
+        }
+    }
+
+    private record ActivityResolution(
+            List<Long> activityIds,
+            List<String> unresolved,
+            List<String> displayNames) {
+    }
+
+    private record ListingMemberTarget(
+            Listing listing,
+            UUID targetUUID,
+            String username) {
     }
 
     public PartyFinderManager() {
@@ -144,6 +170,354 @@ public class PartyFinderManager implements NotificationAccessor {
                     SeqClient.LOGGER.error("Failed to load listings: {}", message, e);
                     pushUiError(message);
                     return List.of();
+                });
+    }
+
+    public CompletableFuture<CommandResult<List<Activity>>> ensureActivitiesLoadedForCommand() {
+        if (!activities.isEmpty()) {
+            return CompletableFuture.completedFuture(
+                    CommandResult.success("Activities ready.", List.copyOf(activities)));
+        }
+
+        return ApiClient.getInstance()
+                .getActivities()
+                .thenApply(result -> {
+                    activities.clear();
+                    activities.addAll(result);
+                    return CommandResult.success("Loaded " + result.size() + " activities.", List.copyOf(result));
+                })
+                .exceptionally(e -> commandFailure(e, "Failed to load activities", "Failed to load activities"));
+    }
+
+    public CompletableFuture<CommandResult<List<Listing>>> refreshListingsForCommand() {
+        return ApiClient.getInstance()
+                .getListings(null, null)
+                .thenApply(result -> {
+                    List<Listing> deduped = deduplicateById(result);
+                    synchronized (listingsLock) {
+                        listings.clear();
+                        listings.addAll(deduped);
+                    }
+                    refreshCurrentListing();
+                    listingsVersion++;
+                    return CommandResult.success("Loaded " + deduped.size() + " listings.", List.copyOf(deduped));
+                })
+                .exceptionally(e -> commandFailure(e, "Failed to load listings", "Failed to load listings"));
+    }
+
+    public CompletableFuture<CommandResult<Listing>> createPartyFromCommand(List<String> activityInputs) {
+        return refreshListingsForCommand()
+                .thenCompose(listingsResult -> {
+                    if (!listingsResult.success()) {
+                        return completedCommandFailure(listingsResult.message());
+                    }
+                    if (currentListing != null) {
+                        return completedCommandFailure("You are already in party #" + currentListing.id()
+                                + ". Use /seq p update or leave/disband it first.");
+                    }
+                    return ensureActivitiesLoadedForCommand()
+                            .thenCompose(activitiesResult -> {
+                                if (!activitiesResult.success()) {
+                                    return completedCommandFailure(activitiesResult.message());
+                                }
+
+                                CommandResult<ActivityResolution> selectionResult = resolveActivitiesForCommand(
+                                        activityInputs,
+                                        true);
+                                if (!selectionResult.success()) {
+                                    return completedCommandFailure(selectionResult.message());
+                                }
+
+                                ActivityResolution resolution = selectionResult.data();
+                                return executeListingCommand(
+                                        ApiClient.getInstance().createListing(
+                                                resolution.activityIds(),
+                                                PartyMode.CHILL,
+                                                false,
+                                                PartyRegion.NA,
+                                                PartyRole.DPS,
+                                                null),
+                                        listing -> applyCreatedListingState(listing),
+                                        "Unable to create party",
+                                        "Failed to create party",
+                                        listing -> "Created party #" + listing.id() + " for "
+                                                + formatActivityNames(resolution.displayNames()) + ".");
+                            });
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> updatePartyFromCommand(List<String> activityInputs) {
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+                    if (!isPartyLeader()) {
+                        return completedCommandFailure("Only the party leader can update the Sequoia listing.");
+                    }
+
+                    Listing listing = currentResult.data();
+                    return ensureActivitiesLoadedForCommand()
+                            .thenCompose(activitiesResult -> {
+                                if (!activitiesResult.success()) {
+                                    return completedCommandFailure(activitiesResult.message());
+                                }
+
+                                CommandResult<ActivityResolution> selectionResult = resolveActivitiesForCommand(
+                                        activityInputs,
+                                        true);
+                                if (!selectionResult.success()) {
+                                    return completedCommandFailure(selectionResult.message());
+                                }
+
+                                ActivityResolution resolution = selectionResult.data();
+                                PartyRegion region = listing.region() != null ? listing.region() : PartyRegion.NA;
+                                return executeListingCommand(
+                                        ApiClient.getInstance().updateListing(
+                                                listing.id(),
+                                                resolution.activityIds(),
+                                                listing.mode(),
+                                                listing.strict(),
+                                                region,
+                                                listing.note()),
+                                        this::applyUpdatedCurrentListingState,
+                                        "Unable to update party",
+                                        "Failed to update party",
+                                        updatedListing -> "Updated party #" + updatedListing.id() + " to "
+                                                + formatActivityNames(resolution.displayNames()) + ".");
+                            });
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> joinPartyFromCommand(long listingId, PartyRole role) {
+        PartyRole resolvedRole = role != null ? role : PartyRole.DPS;
+        return refreshListingsForCommand()
+                .thenCompose(listingsResult -> {
+                    if (!listingsResult.success()) {
+                        return completedCommandFailure(listingsResult.message());
+                    }
+                    if (currentListing != null) {
+                        return completedCommandFailure("You are already in party #" + currentListing.id()
+                                + ". Leave it before joining another listing.");
+                    }
+
+                    return executeListingCommand(
+                            ApiClient.getInstance().joinListing(listingId, resolvedRole),
+                            this::applyJoinedListingState,
+                            "Unable to join party",
+                            "Failed to join party",
+                            listing -> "Joined party #" + listing.id() + " as " + formatRoleName(resolvedRole) + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> leavePartyFromCommand() {
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+
+                    Listing listing = currentResult.data();
+                    return executeListingCommand(
+                            ApiClient.getInstance().leaveListing(listing.id()),
+                            this::applyLeftListingState,
+                            "Unable to leave party",
+                            "Failed to leave party",
+                            ignored -> "Left party #" + listing.id() + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Void>> createInviteFromCommand(String username) {
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailureVoid(currentResult.message());
+                    }
+                    if (!isPartyLeader()) {
+                        return completedCommandFailureVoid("Only the party leader can invite players.");
+                    }
+
+                    String validationMessage = validateUsername(username, false);
+                    if (validationMessage != null) {
+                        return completedCommandFailureVoid(validationMessage);
+                    }
+
+                    String normalizedUsername = username.trim();
+                    Listing listing = currentResult.data();
+                    return resolveUuidForCommand(normalizedUsername)
+                            .thenCompose(uuidResult -> {
+                                if (!uuidResult.success()) {
+                                    return completedCommandFailureVoid(uuidResult.message());
+                                }
+
+                                UUID targetUUID = uuidResult.data();
+                                if (uuidEquals(getLocalPlayerUUID(), targetUUID.toString())) {
+                                    return completedCommandFailureVoid("You cannot invite yourself.");
+                                }
+
+                                return executeVoidCommand(
+                                        ApiClient.getInstance().createInvite(listing.id(), targetUUID),
+                                        "Unable to create party invite",
+                                        "Failed to create invite",
+                                        "Created Sequoia invite for " + normalizedUsername + " on party #"
+                                                + listing.id() + ".");
+                            });
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> setReservedSlotTargetFromCommand(int requestedReservedSlots) {
+        if (requestedReservedSlots < 0) {
+            return completedCommandFailure("Reserved slot target cannot be negative.");
+        }
+
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+                    if (!isPartyLeader()) {
+                        return completedCommandFailure("Only the party leader can reserve slots.");
+                    }
+
+                    Listing listing = currentResult.data();
+                    int currentReservedSlots = inferReservedSlotCount(listing);
+                    int delta = requestedReservedSlots - currentReservedSlots;
+                    if (delta == 0) {
+                        return CompletableFuture.completedFuture(
+                                CommandResult.success(
+                                        "Reserved slots already set to " + requestedReservedSlots + " on party #"
+                                                + listing.id() + ".",
+                                        listing));
+                    }
+
+                    CompletableFuture<Listing> reserveFuture = delta > 0
+                            ? ApiClient.getInstance().reserveSlots(listing.id(), delta)
+                            : ApiClient.getInstance().unreserveSlots(listing.id(), -delta);
+                    String verb = requestedReservedSlots == 1 ? "slot" : "slots";
+                    return executeListingCommand(
+                            reserveFuture,
+                            this::applyUpdatedCurrentListingState,
+                            "Unable to adjust reserved slots",
+                            "Failed to adjust reserved slots",
+                            updatedListing -> "Set reserved slots to " + requestedReservedSlots + " " + verb
+                                    + " on party #" + updatedListing.id() + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> reopenPartyFromCommand() {
+        return runLeaderListingCommand(
+                "Only the party leader can open the Sequoia listing.",
+                listing -> executeListingCommand(
+                        ApiClient.getInstance().reopenListing(listing.id()),
+                        this::applyUpdatedCurrentListingState,
+                        "Unable to reopen party",
+                        "Failed to reopen party",
+                        updatedListing -> "Opened party #" + updatedListing.id() + "."));
+    }
+
+    public CompletableFuture<CommandResult<Listing>> closePartyFromCommand() {
+        return runLeaderListingCommand(
+                "Only the party leader can close the Sequoia listing.",
+                listing -> executeListingCommand(
+                        ApiClient.getInstance().closeListing(listing.id()),
+                        this::applyUpdatedCurrentListingState,
+                        "Unable to close party",
+                        "Failed to close party",
+                        updatedListing -> "Closed party #" + updatedListing.id() + "."));
+    }
+
+    public CompletableFuture<CommandResult<Listing>> disbandPartyFromCommand() {
+        return runLeaderListingCommand(
+                "Only the party leader can disband the Sequoia listing.",
+                listing -> executeListingCommand(
+                        ApiClient.getInstance().disbandListing(listing.id()),
+                        ignored -> applyDisbandedListingState(listing.id()),
+                        "Unable to disband party",
+                        "Failed to disband party",
+                        ignored -> "Disbanded party #" + listing.id() + "."));
+    }
+
+    public CompletableFuture<CommandResult<Listing>> changeRoleFromCommand(PartyRole role) {
+        PartyRole resolvedRole = role != null ? role : PartyRole.DPS;
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+
+                    return executeListingCommand(
+                            ApiClient.getInstance().changeMyRole(resolvedRole),
+                            this::applyUpdatedCurrentListingState,
+                            "Unable to change role",
+                            "Failed to change role",
+                            updatedListing -> "Changed your party role to " + formatRoleName(resolvedRole) + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> kickMemberFromCommand(String username) {
+        return resolveCurrentMemberTargetForCommand(username, true)
+                .thenCompose(targetResult -> {
+                    if (!targetResult.success()) {
+                        return completedCommandFailure(targetResult.message());
+                    }
+
+                    ListingMemberTarget target = targetResult.data();
+                    if (uuidEquals(target.listing().leaderUUID(), target.targetUUID().toString())) {
+                        return completedCommandFailure("You cannot kick the party leader.");
+                    }
+
+                    return executeListingCommand(
+                            ApiClient.getInstance().kickMember(target.listing().id(), target.targetUUID()),
+                            this::applyUpdatedCurrentListingState,
+                            "Unable to kick member",
+                            "Failed to kick member",
+                            updatedListing -> "Kicked " + target.username() + " from party #" + updatedListing.id()
+                                    + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Listing>> promoteMemberFromCommand(String username) {
+        return resolveCurrentMemberTargetForCommand(username, true)
+                .thenCompose(targetResult -> {
+                    if (!targetResult.success()) {
+                        return completedCommandFailure(targetResult.message());
+                    }
+
+                    ListingMemberTarget target = targetResult.data();
+                    if (uuidEquals(target.listing().leaderUUID(), target.targetUUID().toString())) {
+                        return completedCommandFailure(target.username() + " is already the party leader.");
+                    }
+
+                    return executeListingCommand(
+                            ApiClient.getInstance().transferLeadership(target.listing().id(), target.targetUUID()),
+                            this::applyUpdatedCurrentListingState,
+                            "Unable to promote member",
+                            "Failed to transfer leadership",
+                            updatedListing -> "Transferred party #" + updatedListing.id() + " leadership to "
+                                    + target.username() + ".");
+                });
+    }
+
+    public CompletableFuture<CommandResult<Void>> createGamePartyFromCommand() {
+        return CompletableFuture.completedFuture(sendGamePartyCreateCommand());
+    }
+
+    public CompletableFuture<CommandResult<Void>> inviteGamePlayerFromCommand(String username) {
+        return CompletableFuture.completedFuture(sendGamePartyInviteCommand(username));
+    }
+
+    public CompletableFuture<CommandResult<Void>> inviteAllCurrentMembersFromCommand() {
+        return ensureCurrentListingForCommand()
+                .thenApply(currentResult -> {
+                    if (!currentResult.success()) {
+                        return CommandResult.failure(currentResult.message());
+                    }
+
+                    InviteAllResult inviteAllResult = inviteAllCurrentMembersInternal(false);
+                    if (!inviteAllResult.success()) {
+                        return CommandResult.failure("Invite all: " + inviteAllResult.message());
+                    }
+                    return CommandResult.success("Invite all: " + inviteAllResult.message(), null);
                 });
     }
 
@@ -775,13 +1149,18 @@ public class PartyFinderManager implements NotificationAccessor {
     }
 
     public InviteAllResult inviteAllCurrentMembers() {
+        return inviteAllCurrentMembersInternal(true);
+    }
+
+    private InviteAllResult inviteAllCurrentMembersInternal(boolean notifyPlayer) {
         if (currentListing == null) {
             return finishInviteAll(
                     false,
                     false,
                     0,
                     0,
-                    "no active party found.");
+                    "no active party found.",
+                    notifyPlayer);
         }
 
         if (!isPartyLeader()) {
@@ -790,7 +1169,8 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "only the party leader can use this.");
+                    "only the party leader can use this.",
+                    notifyPlayer);
         }
 
         var player = SeqClient.mc.player;
@@ -800,7 +1180,8 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "client connection unavailable.");
+                    "client connection unavailable.",
+                    notifyPlayer);
         }
 
         List<Member> members = currentListing.members();
@@ -810,7 +1191,8 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "no valid party members to invite.");
+                    "no valid party members to invite.",
+                    notifyPlayer);
         }
 
         String myUUID = getLocalPlayerUUID();
@@ -859,11 +1241,12 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     skippedCount,
-                    formatInviteAllMessage(0, skippedCount));
+                    formatInviteAllMessage(0, skippedCount),
+                    notifyPlayer);
         }
 
         for (String username : targets) {
-            player.connection.sendCommand("pa " + username);
+            player.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + username);
         }
 
         return finishInviteAll(
@@ -871,7 +1254,8 @@ public class PartyFinderManager implements NotificationAccessor {
                 true,
                 targets.size(),
                 skippedCount,
-                formatInviteAllMessage(targets.size(), skippedCount));
+                formatInviteAllMessage(targets.size(), skippedCount),
+                notifyPlayer);
     }
 
     /** Leaves the current party (no-arg overload). */
@@ -1180,8 +1564,11 @@ public class PartyFinderManager implements NotificationAccessor {
             boolean sentAny,
             int sentCount,
             int skippedCount,
-            String message) {
-        notify(message);
+            String message,
+            boolean notifyPlayer) {
+        if (notifyPlayer) {
+            notify(message);
+        }
         return new InviteAllResult(success, sentAny, sentCount, skippedCount, message);
     }
 
@@ -1198,6 +1585,318 @@ public class PartyFinderManager implements NotificationAccessor {
             return "sent " + sentCount + " " + inviteWord + ". Skipped " + skippedCount + ".";
         }
         return "sent " + sentCount + " " + inviteWord + ".";
+    }
+
+    private static <T> CompletableFuture<CommandResult<T>> completedCommandFailure(String message) {
+        return CompletableFuture.completedFuture(CommandResult.failure(message));
+    }
+
+    private static CompletableFuture<CommandResult<Void>> completedCommandFailureVoid(String message) {
+        return CompletableFuture.completedFuture(CommandResult.failure(message));
+    }
+
+    private <T> CommandResult<T> commandFailure(
+            Throwable throwable,
+            String fallbackMessage,
+            String logMessage) {
+        String errorMessage = extractUserFriendlyApiError(throwable, fallbackMessage);
+        SeqClient.LOGGER.warn("{}: {}", logMessage, errorMessage);
+        return CommandResult.failure(errorMessage);
+    }
+
+    private CompletableFuture<CommandResult<Listing>> executeListingCommand(
+            CompletableFuture<Listing> apiFuture,
+            Consumer<Listing> stateUpdater,
+            String fallbackMessage,
+            String logMessage,
+            Function<Listing, String> successMessageBuilder) {
+        return apiFuture
+                .thenApply(listing -> {
+                    stateUpdater.accept(listing);
+                    return CommandResult.success(successMessageBuilder.apply(listing), listing);
+                })
+                .exceptionally(e -> commandFailure(e, fallbackMessage, logMessage));
+    }
+
+    private CompletableFuture<CommandResult<Void>> executeVoidCommand(
+            CompletableFuture<Void> apiFuture,
+            String fallbackMessage,
+            String logMessage,
+            String successMessage) {
+        return apiFuture
+                .thenApply(ignored -> CommandResult.success(successMessage, null))
+                .exceptionally(e -> commandFailure(e, fallbackMessage, logMessage));
+    }
+
+    private CompletableFuture<CommandResult<Listing>> runLeaderListingCommand(
+            String notLeaderMessage,
+            Function<Listing, CompletableFuture<CommandResult<Listing>>> action) {
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+                    if (!isPartyLeader()) {
+                        return completedCommandFailure(notLeaderMessage);
+                    }
+                    return action.apply(currentResult.data());
+                });
+    }
+
+    private CompletableFuture<CommandResult<Listing>> ensureCurrentListingForCommand() {
+        if (currentListing != null) {
+            return CompletableFuture.completedFuture(
+                    CommandResult.success("Current listing ready.", currentListing));
+        }
+
+        return refreshListingsForCommand()
+                .thenApply(result -> {
+                    if (!result.success()) {
+                        return CommandResult.failure(result.message());
+                    }
+                    if (currentListing == null) {
+                        return CommandResult.failure("You are not currently in a Sequoia party.");
+                    }
+                    return CommandResult.success("Current listing loaded.", currentListing);
+                });
+    }
+
+    private CommandResult<ActivityResolution> resolveActivitiesForCommand(
+            Collection<String> activityInputs,
+            boolean rejectUnresolved) {
+        if (activityInputs == null || activityInputs.isEmpty()) {
+            return CommandResult.failure("Provide at least one activity.");
+        }
+
+        LinkedHashSet<String> normalizedInputs = new LinkedHashSet<>();
+        for (String rawInput : activityInputs) {
+            if (rawInput == null) {
+                continue;
+            }
+            String trimmed = rawInput.trim();
+            if (!trimmed.isEmpty()) {
+                normalizedInputs.add(trimmed);
+            }
+        }
+
+        if (normalizedInputs.isEmpty()) {
+            return CommandResult.failure("Provide at least one activity.");
+        }
+
+        List<Long> activityIds = new ArrayList<>();
+        List<String> unresolved = new ArrayList<>();
+        LinkedHashSet<String> displayNames = new LinkedHashSet<>();
+
+        for (String activityInput : normalizedInputs) {
+            String searchName = PartyListing.displayNameToBackendName(activityInput);
+            Activity activity = activities
+                    .stream()
+                    .filter(candidate -> matchesActivityName(candidate, activityInput, searchName))
+                    .findFirst()
+                    .orElse(null);
+
+            if (activity == null) {
+                unresolved.add(activityInput);
+                continue;
+            }
+
+            if (!activityIds.contains(activity.id())) {
+                activityIds.add(activity.id());
+            }
+            displayNames.add(PartyListing.backendNameToDisplayName(activity.name()));
+        }
+
+        if (displayNames.contains("Prelude to Annihilation") && displayNames.size() > 1) {
+            return CommandResult.failure("Prelude to Annihilation cannot be combined with other activities.");
+        }
+
+        if (activityIds.isEmpty()) {
+            return CommandResult.failure("Unknown activities: " + String.join(", ", unresolved) + ".");
+        }
+
+        if (rejectUnresolved && !unresolved.isEmpty()) {
+            return CommandResult.failure("Unknown activities: " + String.join(", ", unresolved) + ".");
+        }
+
+        return CommandResult.success(
+                "Resolved " + displayNames.size() + " activities.",
+                new ActivityResolution(
+                        List.copyOf(activityIds),
+                        List.copyOf(unresolved),
+                        List.copyOf(displayNames)));
+    }
+
+    private CompletableFuture<CommandResult<UUID>> resolveUuidForCommand(String username) {
+        return PlayerNameCache.resolveUUID(username)
+                .thenApply(resolvedUuid -> {
+                    if (resolvedUuid == null || resolvedUuid.isBlank()) {
+                        return CommandResult.failure("Unable to find a UUID for " + username + ".");
+                    }
+
+                    try {
+                        return CommandResult.success(
+                                "Resolved UUID.",
+                                UUID.fromString(PlayerNameCache.formatUUID(resolvedUuid)));
+                    } catch (IllegalArgumentException e) {
+                        SeqClient.LOGGER.warn("Unable to parse resolved UUID {}", resolvedUuid, e);
+                        return CommandResult.failure("Unable to resolve a valid UUID for " + username + ".");
+                    }
+                });
+    }
+
+    private CompletableFuture<CommandResult<ListingMemberTarget>> resolveCurrentMemberTargetForCommand(
+            String username,
+            boolean requireLeader) {
+        String validationMessage = validateUsername(username, false);
+        if (validationMessage != null) {
+            return completedCommandFailure(validationMessage);
+        }
+
+        String normalizedUsername = username.trim();
+        return ensureCurrentListingForCommand()
+                .thenCompose(currentResult -> {
+                    if (!currentResult.success()) {
+                        return completedCommandFailure(currentResult.message());
+                    }
+                    if (requireLeader && !isPartyLeader()) {
+                        return completedCommandFailure("Only the party leader can manage party members.");
+                    }
+
+                    Listing listing = currentResult.data();
+                    return resolveUuidForCommand(normalizedUsername)
+                            .thenApply(uuidResult -> {
+                                if (!uuidResult.success()) {
+                                    return CommandResult.failure(uuidResult.message());
+                                }
+
+                                UUID targetUUID = uuidResult.data();
+                                Member targetMember = findMemberByUuid(listing, targetUUID);
+                                if (targetMember == null) {
+                                    return CommandResult.failure(
+                                            normalizedUsername + " is not in your Sequoia party.");
+                                }
+
+                                return CommandResult.success(
+                                        "Resolved target member.",
+                                        new ListingMemberTarget(listing, targetUUID, normalizedUsername));
+                            });
+                });
+    }
+
+    private static Member findMemberByUuid(Listing listing, UUID targetUUID) {
+        if (listing == null || targetUUID == null || listing.members() == null) {
+            return null;
+        }
+
+        for (Member member : listing.members()) {
+            if (member != null && uuidEquals(targetUUID.toString(), member.playerUUID())) {
+                return member;
+            }
+        }
+
+        return null;
+    }
+
+    private CommandResult<Void> sendGamePartyCreateCommand() {
+        if (SeqClient.mc.player == null || SeqClient.mc.player.connection == null) {
+            return CommandResult.failure("Client connection unavailable.");
+        }
+
+        SeqClient.mc.player.connection.sendCommand(GAME_PARTY_CREATE_COMMAND);
+        return CommandResult.success("Sent Wynn party create command.", null);
+    }
+
+    private CommandResult<Void> sendGamePartyInviteCommand(String username) {
+        String validationMessage = validateUsername(username, false);
+        if (validationMessage != null) {
+            return CommandResult.failure(validationMessage);
+        }
+        if (SeqClient.mc.player == null || SeqClient.mc.player.connection == null) {
+            return CommandResult.failure("Client connection unavailable.");
+        }
+
+        String normalizedUsername = username.trim();
+        if (SeqClient.mc.player.getName() != null
+                && SeqClient.mc.player.getName().getString().equalsIgnoreCase(normalizedUsername)) {
+            return CommandResult.failure("You cannot invite yourself.");
+        }
+        SeqClient.mc.player.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + normalizedUsername);
+        return CommandResult.success("Sent Wynn party invite to " + normalizedUsername + ".", null);
+    }
+
+    private static String validateUsername(String username, boolean rejectSelf) {
+        if (username == null || username.isBlank()) {
+            return "Enter a valid Minecraft username.";
+        }
+
+        String normalizedUsername = username.trim();
+        if (!normalizedUsername.matches("[A-Za-z0-9_]{3,16}")) {
+            return "Enter a valid Minecraft username.";
+        }
+
+        if (rejectSelf) {
+            var player = SeqClient.mc.player;
+            String myUsername = player != null && player.getName() != null
+                    ? player.getName().getString()
+                    : null;
+            if (myUsername != null && myUsername.equalsIgnoreCase(normalizedUsername)) {
+                return "You cannot target yourself.";
+            }
+        }
+
+        return null;
+    }
+
+    private static String formatActivityNames(Collection<String> displayNames) {
+        if (displayNames == null || displayNames.isEmpty()) {
+            return "Unknown Activity";
+        }
+        return String.join(", ", displayNames);
+    }
+
+    private static String formatRoleName(PartyRole role) {
+        if (role == null) {
+            return "DPS";
+        }
+        return switch (role) {
+            case DPS -> "DPS";
+            case HEALER -> "Healer";
+            case TANK -> "Tank";
+        };
+    }
+
+    private void applyCreatedListingState(Listing listing) {
+        replaceListing(listing);
+        currentListing = listing;
+        listingsVersion++;
+        publishLocalClassUpdate();
+    }
+
+    private void applyJoinedListingState(Listing listing) {
+        replaceListing(listing);
+        currentListing = listing;
+        listingsVersion++;
+        publishLocalClassUpdate();
+    }
+
+    private void applyUpdatedCurrentListingState(Listing listing) {
+        replaceListing(listing);
+        currentListing = listing;
+        listingsVersion++;
+    }
+
+    private void applyLeftListingState(Listing listing) {
+        replaceListing(listing);
+        currentListing = null;
+        listingsVersion++;
+    }
+
+    private void applyDisbandedListingState(long listingId) {
+        listings.removeIf(l -> l.id() == listingId);
+        if (currentListing != null && currentListing.id() == listingId) {
+            currentListing = null;
+        }
+        listingsVersion++;
     }
 
     private void sendGameDirectMessage(UUID targetUUID, String message) {
@@ -1240,11 +1939,7 @@ public class PartyFinderManager implements NotificationAccessor {
         adjustFuture
                 .thenAccept(updatedListing -> {
                     if (updatedListing != null) {
-                        replaceListing(updatedListing);
-                        if (currentListing != null && currentListing.id() == listingId) {
-                            currentListing = updatedListing;
-                        }
-                        listingsVersion++;
+                        applyUpdatedCurrentListingState(updatedListing);
                     }
                 })
                 .exceptionally(e -> {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -346,6 +346,10 @@ public class PartyFinderManager implements NotificationAccessor {
 
                     String normalizedUsername = username.trim();
                     Listing listing = currentResult.data();
+                    String reservedSlotError = validateReservedSlotsForInvite(listing);
+                    if (reservedSlotError != null) {
+                        return completedCommandFailureVoid(reservedSlotError);
+                    }
                     return resolveUuidForCommand(normalizedUsername)
                             .thenCompose(uuidResult -> {
                                 if (!uuidResult.success()) {
@@ -1097,6 +1101,11 @@ public class PartyFinderManager implements NotificationAccessor {
         }
 
         String normalizedUsername = username.trim();
+        String reservedSlotError = validateReservedSlotsForInvite(currentListing);
+        if (reservedSlotError != null) {
+            pushUiError(reservedSlotError);
+            return;
+        }
         SeqClient.LOGGER.info(
                 "[PartyFinderWS] createInvite requested listingId={} username='{}'",
                 currentListing != null ? currentListing.id() : -1,
@@ -2007,6 +2016,13 @@ public class PartyFinderManager implements NotificationAccessor {
             }
         }
         return count;
+    }
+
+    private static String validateReservedSlotsForInvite(Listing listing) {
+        if (inferReservedSlotCount(listing) > 0) {
+            return null;
+        }
+        return "Add at least one reserved slot before creating a party finder invite.";
     }
 
     private void refreshCurrentListing() {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -781,7 +781,7 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "Invite all: no active party found.");
+                    "no active party found.");
         }
 
         if (!isPartyLeader()) {
@@ -790,7 +790,7 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "Invite all: only the party leader can use this.");
+                    "only the party leader can use this.");
         }
 
         var player = SeqClient.mc.player;
@@ -800,7 +800,7 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "Invite all: client connection unavailable.");
+                    "client connection unavailable.");
         }
 
         List<Member> members = currentListing.members();
@@ -810,7 +810,7 @@ public class PartyFinderManager implements NotificationAccessor {
                     false,
                     0,
                     0,
-                    "Invite all: no valid party members to invite.");
+                    "no valid party members to invite.");
         }
 
         String myUUID = getLocalPlayerUUID();
@@ -1188,16 +1188,16 @@ public class PartyFinderManager implements NotificationAccessor {
     private static String formatInviteAllMessage(int sentCount, int skippedCount) {
         if (sentCount <= 0) {
             if (skippedCount > 0) {
-                return "Invite all: no valid party members to invite. Skipped " + skippedCount + ".";
+                return "no valid party members to invite. Skipped " + skippedCount + ".";
             }
-            return "Invite all: no valid party members to invite.";
+            return "no valid party members to invite.";
         }
 
-        String inviteWord = sentCount == 1 ? "invite" : "invites";
+        String inviteWord = sentCount == 1 ? "party invite" : "party invites";
         if (skippedCount > 0) {
-            return "Invite all: sent " + sentCount + " " + inviteWord + ". Skipped " + skippedCount + ".";
+            return "sent " + sentCount + " " + inviteWord + ". Skipped " + skippedCount + ".";
         }
-        return "Invite all: sent " + sentCount + " " + inviteWord + ".";
+        return "sent " + sentCount + " " + inviteWord + ".";
     }
 
     private void sendGameDirectMessage(UUID targetUUID, String message) {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -89,6 +89,16 @@ public class PartyFinderManager implements NotificationAccessor {
             String username) {
     }
 
+    private record InviteAllCandidate(
+            String memberUUID,
+            CompletableFuture<String> usernameFuture) {
+    }
+
+    private record ResolvedInviteTarget(
+            String memberUUID,
+            String username) {
+    }
+
     public PartyFinderManager() {
         SeqClient.LOGGER.info("[PartyFinderWS] Registering party finder websocket handlers");
         // Register for real-time WS updates
@@ -551,10 +561,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .createListing(activityIds, mode, strict, region, role, note)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
-                    publishLocalClassUpdate();
+                    applyCreatedListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -569,10 +576,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .joinListing(listingId, role)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
-                    publishLocalClassUpdate();
+                    applyJoinedListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -590,10 +594,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .joinListing(listingId, role, inviteToken)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
-                    publishLocalClassUpdate();
+                    applyJoinedListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -615,9 +616,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .leaveListing(listingId)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = null;
-                    listingsVersion++;
+                    applyLeftListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -630,9 +629,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .closeListing(listingId)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
+                    applyUpdatedCurrentListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -645,9 +642,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .reopenListing(listingId)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
+                    applyUpdatedCurrentListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -696,9 +691,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .changeMyRole(role)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
+                    applyUpdatedCurrentListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -716,9 +709,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .reassignRole(listingId, targetUUID, role)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
+                    applyUpdatedCurrentListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -733,9 +724,7 @@ public class PartyFinderManager implements NotificationAccessor {
         return ApiClient.getInstance()
                 .transferLeadership(listingId, targetUUID)
                 .thenApply(listing -> {
-                    replaceListing(listing);
-                    currentListing = listing;
-                    listingsVersion++;
+                    applyUpdatedCurrentListingState(listing);
                     return listing;
                 })
                 .exceptionally(e -> {
@@ -1024,8 +1013,11 @@ public class PartyFinderManager implements NotificationAccessor {
             return;
         PartyMember member = party.members.get(memberIndex);
         try {
-            UUID targetUUID = UUID.fromString(
-                    PlayerNameCache.formatUUID(member.playerUUID));
+            String formattedTargetUuid = PlayerNameCache.formatUUID(member.playerUUID);
+            if (formattedTargetUuid == null) {
+                throw new IllegalArgumentException("Unparseable member UUID");
+            }
+            UUID targetUUID = UUID.fromString(formattedTargetUuid);
             transferLeadership(party.id, targetUUID)
                     .thenAccept(listing -> {
                         if (listing != null) {
@@ -1055,8 +1047,11 @@ public class PartyFinderManager implements NotificationAccessor {
             return;
         PartyMember member = party.members.get(memberIndex);
         try {
-            UUID targetUUID = UUID.fromString(
-                    PlayerNameCache.formatUUID(member.playerUUID));
+            String formattedTargetUuid = PlayerNameCache.formatUUID(member.playerUUID);
+            if (formattedTargetUuid == null) {
+                throw new IllegalArgumentException("Unparseable member UUID");
+            }
+            UUID targetUUID = UUID.fromString(formattedTargetUuid);
             kickMember(party.id, targetUUID)
                     .thenAccept(listing -> {
                         if (listing != null) {
@@ -1104,14 +1099,16 @@ public class PartyFinderManager implements NotificationAccessor {
         }
 
         String normalizedUsername = username.trim();
-        String reservedSlotError = validateReservedSlotsForInvite(currentListing);
+        Listing requestedListing = currentListing;
+        long requestedListingId = requestedListing.id();
+        String reservedSlotError = validateReservedSlotsForInvite(requestedListing);
         if (reservedSlotError != null) {
             pushUiError(reservedSlotError);
             return;
         }
         SeqClient.LOGGER.info(
                 "[PartyFinderWS] createInvite requested listingId={} username='{}'",
-                currentListing != null ? currentListing.id() : -1,
+                requestedListingId,
                 normalizedUsername);
         if (!normalizedUsername.matches("[A-Za-z0-9_]{3,16}")) {
             pushUiError("Enter a valid Minecraft username.");
@@ -1138,9 +1135,16 @@ public class PartyFinderManager implements NotificationAccessor {
                         return CompletableFuture.completedFuture(false);
                     }
 
+                    String formattedResolvedUuid = PlayerNameCache.formatUUID(resolvedUUID);
+                    if (formattedResolvedUuid == null) {
+                        SeqClient.LOGGER.warn("Unable to normalize resolved invite UUID: {}", resolvedUUID);
+                        pushUiError("Unable to resolve a valid UUID for that player.");
+                        return CompletableFuture.completedFuture(false);
+                    }
+
                     UUID targetUUID;
                     try {
-                        targetUUID = UUID.fromString(PlayerNameCache.formatUUID(resolvedUUID));
+                        targetUUID = UUID.fromString(formattedResolvedUuid);
                     } catch (IllegalArgumentException e) {
                         SeqClient.LOGGER.warn("Unable to parse resolved invite UUID: {}", resolvedUUID, e);
                         pushUiError("Unable to resolve a valid UUID for that player.");
@@ -1152,18 +1156,33 @@ public class PartyFinderManager implements NotificationAccessor {
                             "[PartyFinderWS] createInvite normalized targetUUID={} myUUID={} listingId={}",
                             targetUUID,
                             myUUID,
-                            currentListing != null ? currentListing.id() : -1);
+                            requestedListingId);
                     if (myUUID != null && myUUID.equalsIgnoreCase(targetUUID.toString())) {
                         pushUiError("You cannot invite yourself.");
                         return CompletableFuture.completedFuture(false);
                     }
 
+                    if (currentListing == null || currentListing.id() != requestedListingId) {
+                        pushUiError("Your active party changed before the invite was created. Try again.");
+                        return CompletableFuture.completedFuture(false);
+                    }
+                    if (!isPartyLeader()) {
+                        pushUiError("Only the party leader can invite players.");
+                        return CompletableFuture.completedFuture(false);
+                    }
+
+                    String latestReservedSlotError = validateReservedSlotsForInvite(currentListing);
+                    if (latestReservedSlotError != null) {
+                        pushUiError(latestReservedSlotError);
+                        return CompletableFuture.completedFuture(false);
+                    }
+
                     SeqClient.LOGGER.info(
                             "[PartyFinderWS] createInvite calling API listingId={} targetUUID={}",
-                            currentListing.id(),
+                            requestedListingId,
                             targetUUID);
                     return ApiClient.getInstance()
-                            .createInvite(currentListing.id(), targetUUID)
+                            .createInvite(requestedListingId, targetUUID)
                             .thenApply(ignored -> true);
                 })
                 .thenAccept(inviteCreated -> {
@@ -1217,7 +1236,9 @@ public class PartyFinderManager implements NotificationAccessor {
                     notifyPlayer));
         }
 
-        List<Member> members = currentListing.members();
+        Listing listingSnapshot = currentListing;
+        long listingId = listingSnapshot.id();
+        List<Member> members = listingSnapshot.members();
         if (members == null || members.isEmpty()) {
             return CompletableFuture.completedFuture(finishInviteAll(
                     true,
@@ -1229,7 +1250,7 @@ public class PartyFinderManager implements NotificationAccessor {
         }
 
         String myUUID = getLocalPlayerUUID();
-        List<CompletableFuture<String>> usernameFutures = new ArrayList<>();
+        List<InviteAllCandidate> inviteCandidates = new ArrayList<>();
         int skippedCount = 0;
 
         for (Member member : members) {
@@ -1248,11 +1269,12 @@ public class PartyFinderManager implements NotificationAccessor {
                 continue;
             }
 
-            usernameFutures.add(PlayerNameCache.resolveAsync(memberUUID)
-                    .exceptionally(ignored -> null));
+            inviteCandidates.add(new InviteAllCandidate(
+                    memberUUID,
+                    PlayerNameCache.resolveAsync(memberUUID).exceptionally(ignored -> null)));
         }
 
-        if (usernameFutures.isEmpty()) {
+        if (inviteCandidates.isEmpty()) {
             return CompletableFuture.completedFuture(finishInviteAll(
                     true,
                     false,
@@ -1263,14 +1285,26 @@ public class PartyFinderManager implements NotificationAccessor {
         }
 
         int baseSkippedCount = skippedCount;
-        return CompletableFuture.allOf(usernameFutures.toArray(CompletableFuture[]::new))
+        return CompletableFuture.allOf(inviteCandidates.stream()
+                        .map(InviteAllCandidate::usernameFuture)
+                        .toArray(CompletableFuture[]::new))
                 .thenCompose(ignored -> {
-                    List<String> targets = new ArrayList<>();
+                    if (currentListing == null || currentListing.id() != listingId) {
+                        return CompletableFuture.completedFuture(finishInviteAll(
+                                false,
+                                false,
+                                0,
+                                baseSkippedCount,
+                                "your active party changed before invites could be sent.",
+                                notifyPlayer));
+                    }
+
+                    List<ResolvedInviteTarget> targets = new ArrayList<>();
                     Set<String> seenTargets = new LinkedHashSet<>();
                     int resolvedSkippedCount = baseSkippedCount;
 
-                    for (CompletableFuture<String> usernameFuture : usernameFutures) {
-                        String username = usernameFuture.getNow(null);
+                    for (InviteAllCandidate inviteCandidate : inviteCandidates) {
+                        String username = inviteCandidate.usernameFuture().getNow(null);
                         if (username == null
                                 || username.isBlank()
                                 || "Loading...".equalsIgnoreCase(username)
@@ -1286,7 +1320,7 @@ public class PartyFinderManager implements NotificationAccessor {
                             continue;
                         }
 
-                        targets.add(username);
+                        targets.add(new ResolvedInviteTarget(inviteCandidate.memberUUID(), username));
                     }
 
                     if (targets.isEmpty()) {
@@ -1314,16 +1348,46 @@ public class PartyFinderManager implements NotificationAccessor {
                             return;
                         }
 
-                        for (String username : targets) {
-                            currentPlayer.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + username);
+                        if (currentListing == null || currentListing.id() != listingId) {
+                            dispatchFuture.complete(finishInviteAll(
+                                    false,
+                                    false,
+                                    0,
+                                    finalSkippedCount,
+                                    "your active party changed before invites could be sent.",
+                                    notifyPlayer));
+                            return;
+                        }
+                        if (!isPartyLeader()) {
+                            dispatchFuture.complete(finishInviteAll(
+                                    false,
+                                    false,
+                                    0,
+                                    finalSkippedCount,
+                                    "only the party leader can use this.",
+                                    notifyPlayer));
+                            return;
+                        }
+
+                        Set<String> activeMemberKeys = collectListingMemberKeys(currentListing);
+                        int sentCount = 0;
+                        int skippedAtDispatch = finalSkippedCount;
+                        for (ResolvedInviteTarget target : targets) {
+                            String memberKey = normalizeUuidLike(target.memberUUID());
+                            if (memberKey == null || !activeMemberKeys.contains(memberKey)) {
+                                skippedAtDispatch++;
+                                continue;
+                            }
+                            currentPlayer.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + target.username());
+                            sentCount++;
                         }
 
                         dispatchFuture.complete(finishInviteAll(
                                 true,
-                                true,
-                                targets.size(),
-                                finalSkippedCount,
-                                formatInviteAllMessage(targets.size(), finalSkippedCount),
+                                sentCount > 0,
+                                sentCount,
+                                skippedAtDispatch,
+                                formatInviteAllMessage(sentCount, skippedAtDispatch),
                                 notifyPlayer));
                     });
                     return dispatchFuture;
@@ -1477,9 +1541,7 @@ public class PartyFinderManager implements NotificationAccessor {
                         currentListing.note())
                 .thenAccept(listing -> {
                     if (listing != null) {
-                        replaceListing(listing);
-                        currentListing = listing;
-                        listingsVersion++;
+                        applyUpdatedCurrentListingState(listing);
                         applyReservedSlotTarget(
                                 listing.id(),
                                 currentReservedSlots,
@@ -1805,10 +1867,16 @@ public class PartyFinderManager implements NotificationAccessor {
                         return CommandResult.failure("Unable to find a UUID for " + username + ".");
                     }
 
+                    String formattedResolvedUuid = PlayerNameCache.formatUUID(resolvedUuid);
+                    if (formattedResolvedUuid == null) {
+                        SeqClient.LOGGER.warn("Unable to normalize resolved UUID {}", resolvedUuid);
+                        return CommandResult.failure("Unable to resolve a valid UUID for " + username + ".");
+                    }
+
                     try {
                         return CommandResult.success(
                                 "Resolved UUID.",
-                                UUID.fromString(PlayerNameCache.formatUUID(resolvedUuid)));
+                                UUID.fromString(formattedResolvedUuid));
                     } catch (IllegalArgumentException e) {
                         SeqClient.LOGGER.warn("Unable to parse resolved UUID {}", resolvedUuid, e);
                         return CommandResult.failure("Unable to resolve a valid UUID for " + username + ".");
@@ -1969,27 +2037,43 @@ public class PartyFinderManager implements NotificationAccessor {
 
     private void applyCreatedListingState(Listing listing) {
         replaceListing(listing);
-        currentListing = listing;
+        boolean shouldPublishClassUpdate = false;
+        if (currentListing == null || currentListing.id() == listing.id()) {
+            currentListing = listing;
+            shouldPublishClassUpdate = true;
+        }
         listingsVersion++;
-        publishLocalClassUpdate();
+        if (shouldPublishClassUpdate) {
+            publishLocalClassUpdate();
+        }
     }
 
     private void applyJoinedListingState(Listing listing) {
         replaceListing(listing);
-        currentListing = listing;
+        boolean shouldPublishClassUpdate = false;
+        if (currentListing == null || currentListing.id() == listing.id()) {
+            currentListing = listing;
+            shouldPublishClassUpdate = true;
+        }
         listingsVersion++;
-        publishLocalClassUpdate();
+        if (shouldPublishClassUpdate) {
+            publishLocalClassUpdate();
+        }
     }
 
     private void applyUpdatedCurrentListingState(Listing listing) {
         replaceListing(listing);
-        currentListing = listing;
+        if (currentListing != null && currentListing.id() == listing.id()) {
+            currentListing = listing;
+        }
         listingsVersion++;
     }
 
     private void applyLeftListingState(Listing listing) {
         replaceListing(listing);
-        currentListing = null;
+        if (currentListing != null && currentListing.id() == listing.id()) {
+            currentListing = null;
+        }
         listingsVersion++;
     }
 
@@ -2158,6 +2242,25 @@ public class PartyFinderManager implements NotificationAccessor {
         return false;
     }
 
+    private static Set<String> collectListingMemberKeys(Listing listing) {
+        LinkedHashSet<String> memberKeys = new LinkedHashSet<>();
+        if (listing == null || listing.members() == null) {
+            return memberKeys;
+        }
+
+        for (Member member : listing.members()) {
+            if (member == null) {
+                continue;
+            }
+
+            String memberKey = normalizeUuidLike(member.playerUUID());
+            if (memberKey != null) {
+                memberKeys.add(memberKey);
+            }
+        }
+        return memberKeys;
+    }
+
     private static boolean uuidEquals(String left, String right) {
         String leftNorm = normalizeUuidLike(left);
         String rightNorm = normalizeUuidLike(right);
@@ -2178,6 +2281,9 @@ public class PartyFinderManager implements NotificationAccessor {
         }
 
         String formatted = PlayerNameCache.formatUUID(trimmed);
+        if (formatted == null) {
+            return trimmed.toLowerCase(Locale.ROOT);
+        }
         StringBuilder hex = new StringBuilder(32);
         for (int i = 0; i < formatted.length(); i++) {
             char ch = Character.toLowerCase(formatted.charAt(i));

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -1624,7 +1624,7 @@ public class PartyFinderManager implements NotificationAccessor {
             String logMessage,
             String successMessage) {
         return apiFuture
-                .thenApply(ignored -> CommandResult.success(successMessage, null))
+                .thenApply(ignored -> CommandResult.<Void>success(successMessage, null))
                 .exceptionally(e -> commandFailure(e, fallbackMessage, logMessage));
     }
 

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -1871,7 +1871,9 @@ public class PartyFinderManager implements NotificationAccessor {
         if (displayNames == null || displayNames.isEmpty()) {
             return "Unknown Activity";
         }
-        return String.join(", ", displayNames);
+        return displayNames.stream()
+                .map(PartyListing::displayNameToBackendName)
+                .collect(Collectors.joining(", "));
     }
 
     private static String formatRoleName(PartyRole role) {
@@ -2129,12 +2131,22 @@ public class PartyFinderManager implements NotificationAccessor {
 
         String backendName = activity.name().trim();
         String mappedDisplay = PartyListing.backendNameToDisplayName(backendName);
-        String mappedBackendFromDisplay = PartyListing.displayNameToBackendName(displayName);
+        String candidateCode = PartyListing.displayNameToBackendName(mappedDisplay);
+
+        String inputDisplay = PartyListing.backendNameToDisplayName(displayName);
+        String inputCode = PartyListing.displayNameToBackendName(inputDisplay);
+
+        String searchDisplay = PartyListing.backendNameToDisplayName(backendSearchName);
+        String searchCode = PartyListing.displayNameToBackendName(searchDisplay);
 
         if (backendName.equalsIgnoreCase(backendSearchName)
                 || backendName.equalsIgnoreCase(displayName)
                 || mappedDisplay.equalsIgnoreCase(displayName)
-                || backendName.equalsIgnoreCase(mappedBackendFromDisplay)) {
+                || mappedDisplay.equalsIgnoreCase(inputDisplay)
+                || candidateCode.equalsIgnoreCase(backendSearchName)
+                || candidateCode.equalsIgnoreCase(displayName)
+                || candidateCode.equalsIgnoreCase(inputCode)
+                || candidateCode.equalsIgnoreCase(searchCode)) {
             return true;
         }
 
@@ -2142,12 +2154,21 @@ public class PartyFinderManager implements NotificationAccessor {
         String normalizedDisplay = normalizeActivityKey(displayName);
         String normalizedMappedDisplay = normalizeActivityKey(mappedDisplay);
         String normalizedBackendSearch = normalizeActivityKey(backendSearchName);
-        String normalizedMappedBackend = normalizeActivityKey(mappedBackendFromDisplay);
+        String normalizedCandidateCode = normalizeActivityKey(candidateCode);
+        String normalizedInputDisplay = normalizeActivityKey(inputDisplay);
+        String normalizedInputCode = normalizeActivityKey(inputCode);
+        String normalizedSearchDisplay = normalizeActivityKey(searchDisplay);
+        String normalizedSearchCode = normalizeActivityKey(searchCode);
 
         return normalizedBackend.equals(normalizedDisplay)
                 || normalizedMappedDisplay.equals(normalizedDisplay)
+                || normalizedMappedDisplay.equals(normalizedInputDisplay)
                 || normalizedBackend.equals(normalizedBackendSearch)
-                || normalizedBackend.equals(normalizedMappedBackend);
+                || normalizedMappedDisplay.equals(normalizedSearchDisplay)
+                || normalizedCandidateCode.equals(normalizedDisplay)
+                || normalizedCandidateCode.equals(normalizedBackendSearch)
+                || normalizedCandidateCode.equals(normalizedInputCode)
+                || normalizedCandidateCode.equals(normalizedSearchCode);
     }
 
     private static String normalizeActivityKey(String value) {

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -831,7 +831,6 @@ public class PartyFinderManager implements NotificationAccessor {
             }
 
             if (uuidEquals(myUUID, memberUUID)) {
-                skippedCount++;
                 continue;
             }
 

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ public class PartyFinderManager implements NotificationAccessor {
                     Instant.class,
                     (JsonDeserializer<Instant>) (json, type, ctx) -> Instant.parse(json.getAsString()))
             .create();
+    private static final long INVITE_NAME_LOOKUP_TIMEOUT_SECONDS = 3L;
     private static final String GAME_PARTY_CREATE_COMMAND = "party create";
     private static final String GAME_PARTY_INVITE_PREFIX = "party invite ";
 
@@ -819,25 +821,30 @@ public class PartyFinderManager implements NotificationAccessor {
             refreshCurrentListing();
         }
 
-        String inviterName = PlayerNameCache.resolve(inviterUUID);
-        if (inviterName == null || inviterName.isBlank() || "Loading...".equals(inviterName)) {
-            inviterName = "a player";
-        }
-        SeqClient.LOGGER.info("[PartyFinderWS] Resolved inviter name='{}' for uuid={}", inviterName, inviterUUID);
+        PlayerNameCache.resolveAsync(inviterUUID)
+                .completeOnTimeout(null, INVITE_NAME_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .whenComplete((resolvedName, error) -> {
+                    String inviterName = formatInviterName(resolvedName);
+                    SeqClient.LOGGER.info(
+                            "[PartyFinderWS] Resolved inviter name='{}' for uuid={}",
+                            inviterName,
+                            inviterUUID);
 
-        if (inviteToken == null || inviteToken.isBlank()) {
-            SeqClient.LOGGER.info("[PartyFinderWS] Invite token missing; sending plain notification for listing {}",
-                    listingId);
-            notify("Party Finder invite from " + inviterName + ".");
-        } else {
-            SeqClient.LOGGER.info(
-                    "[PartyFinderWS] Invite token present; sending clickable invite notification for listing {}",
-                    listingId);
-            notifyInviteWithJoinAction(
-                    "Party Finder invite from " + inviterName + ".",
-                    listingId,
-                    inviteToken);
-        }
+                    if (inviteToken == null || inviteToken.isBlank()) {
+                        SeqClient.LOGGER.info(
+                                "[PartyFinderWS] Invite token missing; sending plain notification for listing {}",
+                                listingId);
+                        notify("Party Finder invite from " + inviterName + ".");
+                    } else {
+                        SeqClient.LOGGER.info(
+                                "[PartyFinderWS] Invite token present; sending clickable invite notification for listing {}",
+                                listingId);
+                        notifyInviteWithJoinAction(
+                                "Party Finder invite from " + inviterName + ".",
+                                listingId,
+                                inviteToken);
+                    }
+                });
 
         SeqClient.LOGGER.info(
                 "Received party_finder_invite listingId={} inviterUUID={} tokenPresent={}",
@@ -881,20 +888,23 @@ public class PartyFinderManager implements NotificationAccessor {
                     + quoteForCommand(inviteToken);
             String denyCommand = "/_seqinvite deny " + listingId;
 
+            ClickEvent joinClickEvent = new ClickEvent.RunCommand(joinCommand);
+            ClickEvent denyClickEvent = new ClickEvent.RunCommand(denyCommand);
+
             MutableComponent fullMessage = NotificationAccessor.prefixComponent()
                     .append(Component.literal(String.valueOf(message)).withStyle(ChatFormatting.GRAY))
                     .append(Component.literal(" "))
-                    .append(Component.literal("[Join]")
-                            .withStyle(style -> style
-                                    .withColor(ChatFormatting.GREEN)
-                                    .withBold(true)
-                                    .withClickEvent(new ClickEvent.RunCommand(joinCommand))))
+                    .append(NotificationAccessor.wynnPill(
+                            "join",
+                            ChatFormatting.GREEN,
+                            ChatFormatting.WHITE,
+                            joinClickEvent))
                     .append(Component.literal(" "))
-                    .append(Component.literal("[Deny]")
-                            .withStyle(style -> style
-                                    .withColor(ChatFormatting.RED)
-                                    .withBold(true)
-                                    .withClickEvent(new ClickEvent.RunCommand(denyCommand))));
+                    .append(NotificationAccessor.wynnPill(
+                            "deny",
+                            ChatFormatting.RED,
+                            ChatFormatting.WHITE,
+                            denyClickEvent));
 
             SeqClient.LOGGER.info(
                     "[PartyFinderWS] Displaying invite chat message listingId={} player={} joinCommand={} denyCommand={}",
@@ -913,6 +923,16 @@ public class PartyFinderManager implements NotificationAccessor {
         return "\"" + value
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"") + "\"";
+    }
+
+    private static String formatInviterName(String inviterName) {
+        if (inviterName == null
+                || inviterName.isBlank()
+                || "Loading...".equalsIgnoreCase(inviterName)
+                || "Unknown".equalsIgnoreCase(inviterName)) {
+            return "a player";
+        }
+        return inviterName;
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyFinderManager.java
@@ -514,16 +514,15 @@ public class PartyFinderManager implements NotificationAccessor {
 
     public CompletableFuture<CommandResult<Void>> inviteAllCurrentMembersFromCommand() {
         return ensureCurrentListingForCommand()
-                .thenApply(currentResult -> {
+                .thenCompose(currentResult -> {
                     if (!currentResult.success()) {
-                        return CommandResult.failure(currentResult.message());
+                        return completedCommandFailureVoid(currentResult.message());
                     }
 
-                    InviteAllResult inviteAllResult = inviteAllCurrentMembersInternal(false);
-                    if (!inviteAllResult.success()) {
-                        return CommandResult.failure("Invite all: " + inviteAllResult.message());
-                    }
-                    return CommandResult.success("Invite all: " + inviteAllResult.message(), null);
+                    return inviteAllCurrentMembersInternal(false)
+                            .thenApply(inviteAllResult -> inviteAllResult.success()
+                                    ? CommandResult.success("Invite all: " + inviteAllResult.message(), null)
+                                    : CommandResult.failure("Invite all: " + inviteAllResult.message()));
                 });
     }
 
@@ -1178,56 +1177,55 @@ public class PartyFinderManager implements NotificationAccessor {
                 });
     }
 
-    public InviteAllResult inviteAllCurrentMembers() {
+    public CompletableFuture<InviteAllResult> inviteAllCurrentMembers() {
         return inviteAllCurrentMembersInternal(true);
     }
 
-    private InviteAllResult inviteAllCurrentMembersInternal(boolean notifyPlayer) {
+    private CompletableFuture<InviteAllResult> inviteAllCurrentMembersInternal(boolean notifyPlayer) {
         if (currentListing == null) {
-            return finishInviteAll(
+            return CompletableFuture.completedFuture(finishInviteAll(
                     false,
                     false,
                     0,
                     0,
                     "no active party found.",
-                    notifyPlayer);
+                    notifyPlayer));
         }
 
         if (!isPartyLeader()) {
-            return finishInviteAll(
+            return CompletableFuture.completedFuture(finishInviteAll(
                     false,
                     false,
                     0,
                     0,
                     "only the party leader can use this.",
-                    notifyPlayer);
+                    notifyPlayer));
         }
 
         var player = SeqClient.mc.player;
         if (player == null || player.connection == null) {
-            return finishInviteAll(
+            return CompletableFuture.completedFuture(finishInviteAll(
                     false,
                     false,
                     0,
                     0,
                     "client connection unavailable.",
-                    notifyPlayer);
+                    notifyPlayer));
         }
 
         List<Member> members = currentListing.members();
         if (members == null || members.isEmpty()) {
-            return finishInviteAll(
+            return CompletableFuture.completedFuture(finishInviteAll(
                     true,
                     false,
                     0,
                     0,
                     "no valid party members to invite.",
-                    notifyPlayer);
+                    notifyPlayer));
         }
 
         String myUUID = getLocalPlayerUUID();
-        List<String> targets = new ArrayList<>();
-        Set<String> seenTargets = new LinkedHashSet<>();
+        List<CompletableFuture<String>> usernameFutures = new ArrayList<>();
         int skippedCount = 0;
 
         for (Member member : members) {
@@ -1246,46 +1244,86 @@ public class PartyFinderManager implements NotificationAccessor {
                 continue;
             }
 
-            String username = PlayerNameCache.resolve(memberUUID);
-            if (username == null
-                    || username.isBlank()
-                    || "Loading...".equalsIgnoreCase(username)
-                    || "Unknown".equalsIgnoreCase(username)
-                    || !username.matches("[A-Za-z0-9_]{3,16}")) {
-                skippedCount++;
-                continue;
-            }
-
-            String normalizedUsername = username.toLowerCase(Locale.ROOT);
-            if (!seenTargets.add(normalizedUsername)) {
-                skippedCount++;
-                continue;
-            }
-
-            targets.add(username);
+            usernameFutures.add(PlayerNameCache.resolveAsync(memberUUID)
+                    .exceptionally(ignored -> null));
         }
 
-        if (targets.isEmpty()) {
-            return finishInviteAll(
+        if (usernameFutures.isEmpty()) {
+            return CompletableFuture.completedFuture(finishInviteAll(
                     true,
                     false,
                     0,
                     skippedCount,
                     formatInviteAllMessage(0, skippedCount),
-                    notifyPlayer);
+                    notifyPlayer));
         }
 
-        for (String username : targets) {
-            player.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + username);
-        }
+        int baseSkippedCount = skippedCount;
+        return CompletableFuture.allOf(usernameFutures.toArray(CompletableFuture[]::new))
+                .thenCompose(ignored -> {
+                    List<String> targets = new ArrayList<>();
+                    Set<String> seenTargets = new LinkedHashSet<>();
+                    int resolvedSkippedCount = baseSkippedCount;
 
-        return finishInviteAll(
-                true,
-                true,
-                targets.size(),
-                skippedCount,
-                formatInviteAllMessage(targets.size(), skippedCount),
-                notifyPlayer);
+                    for (CompletableFuture<String> usernameFuture : usernameFutures) {
+                        String username = usernameFuture.getNow(null);
+                        if (username == null
+                                || username.isBlank()
+                                || "Loading...".equalsIgnoreCase(username)
+                                || "Unknown".equalsIgnoreCase(username)
+                                || !username.matches("[A-Za-z0-9_]{3,16}")) {
+                            resolvedSkippedCount++;
+                            continue;
+                        }
+
+                        String normalizedUsername = username.toLowerCase(Locale.ROOT);
+                        if (!seenTargets.add(normalizedUsername)) {
+                            resolvedSkippedCount++;
+                            continue;
+                        }
+
+                        targets.add(username);
+                    }
+
+                    if (targets.isEmpty()) {
+                        return CompletableFuture.completedFuture(finishInviteAll(
+                                true,
+                                false,
+                                0,
+                                resolvedSkippedCount,
+                                formatInviteAllMessage(0, resolvedSkippedCount),
+                                notifyPlayer));
+                    }
+
+                    CompletableFuture<InviteAllResult> dispatchFuture = new CompletableFuture<>();
+                    int finalSkippedCount = resolvedSkippedCount;
+                    SeqClient.mc.execute(() -> {
+                        var currentPlayer = SeqClient.mc.player;
+                        if (currentPlayer == null || currentPlayer.connection == null) {
+                            dispatchFuture.complete(finishInviteAll(
+                                    false,
+                                    false,
+                                    0,
+                                    finalSkippedCount,
+                                    "client connection unavailable.",
+                                    notifyPlayer));
+                            return;
+                        }
+
+                        for (String username : targets) {
+                            currentPlayer.connection.sendCommand(GAME_PARTY_INVITE_PREFIX + username);
+                        }
+
+                        dispatchFuture.complete(finishInviteAll(
+                                true,
+                                true,
+                                targets.size(),
+                                finalSkippedCount,
+                                formatInviteAllMessage(targets.size(), finalSkippedCount),
+                                notifyPlayer));
+                    });
+                    return dispatchFuture;
+                });
     }
 
     /** Leaves the current party (no-arg overload). */

--- a/src/main/java/org/sequoia/seq/managers/PartyListing.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyListing.java
@@ -2,6 +2,7 @@ package org.sequoia.seq.managers;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,8 @@ public class PartyListing {
      * raids).
      */
     private static final Map<String, String> DISPLAY_TO_ASSET = new LinkedHashMap<>();
+    private static final List<String> ACTIVITY_COMMAND_ALIASES;
+    private static final List<String> ACTIVITY_DISPLAY_NAMES;
 
     static {
         register("Nest of the Grootslangs", "NOTG", "notg");
@@ -52,6 +55,12 @@ public class PartyListing {
         // Backend aliases observed in API payloads
         BACKEND_TO_DISPLAY.put("The Orphion's Nexus of Light", "Nexus of Light");
         BACKEND_TO_DISPLAY.put("The Orphions Nexus of Light", "Nexus of Light");
+
+        LinkedHashSet<String> aliases = new LinkedHashSet<>();
+        aliases.addAll(DISPLAY_TO_BACKEND.keySet());
+        aliases.addAll(BACKEND_TO_DISPLAY.keySet());
+        ACTIVITY_COMMAND_ALIASES = List.copyOf(aliases);
+        ACTIVITY_DISPLAY_NAMES = List.copyOf(DISPLAY_TO_BACKEND.keySet());
     }
 
     private static void register(
@@ -117,6 +126,14 @@ public class PartyListing {
         String trimmed = displayName.trim();
         String mapped = lookupIgnoreCase(DISPLAY_TO_BACKEND, trimmed);
         return mapped != null ? mapped : trimmed;
+    }
+
+    public static List<String> activityCommandAliases() {
+        return ACTIVITY_COMMAND_ALIASES;
+    }
+
+    public static List<String> activityDisplayNames() {
+        return ACTIVITY_DISPLAY_NAMES;
     }
 
     private static String lookupIgnoreCase(

--- a/src/main/java/org/sequoia/seq/managers/PartyListing.java
+++ b/src/main/java/org/sequoia/seq/managers/PartyListing.java
@@ -56,10 +56,7 @@ public class PartyListing {
         BACKEND_TO_DISPLAY.put("The Orphion's Nexus of Light", "Nexus of Light");
         BACKEND_TO_DISPLAY.put("The Orphions Nexus of Light", "Nexus of Light");
 
-        LinkedHashSet<String> aliases = new LinkedHashSet<>();
-        aliases.addAll(DISPLAY_TO_BACKEND.keySet());
-        aliases.addAll(BACKEND_TO_DISPLAY.keySet());
-        ACTIVITY_COMMAND_ALIASES = List.copyOf(aliases);
+        ACTIVITY_COMMAND_ALIASES = List.copyOf(new LinkedHashSet<>(DISPLAY_TO_BACKEND.values()));
         ACTIVITY_DISPLAY_NAMES = List.copyOf(DISPLAY_TO_BACKEND.keySet());
     }
 

--- a/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
+++ b/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
@@ -2506,8 +2506,9 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
                 return true;
             }
             if (isHovered(mx, my, headerLayout.inviteAllButton())) {
-                PartyFinderManager.InviteAllResult inviteAllResult = party().inviteAllCurrentMembers();
-                showStatusBanner(inviteAllResult.message());
+                showStatusBanner("Preparing party invites...");
+                party().inviteAllCurrentMembers().thenAccept(inviteAllResult -> SeqClient.mc.execute(() ->
+                        showStatusBanner(inviteAllResult.message())));
                 return true;
             }
         } else {

--- a/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
+++ b/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
@@ -16,6 +16,7 @@ import org.lwjgl.nanovg.NVGPaint;
 import org.sequoia.seq.accessors.PartyAccessor;
 import org.sequoia.seq.client.SeqClient;
 import org.sequoia.seq.managers.AssetManager;
+import org.sequoia.seq.managers.PartyFinderManager;
 import org.sequoia.seq.managers.PartyListing;
 import org.sequoia.seq.managers.PartyMember;
 import org.sequoia.seq.model.Activity;
@@ -46,6 +47,15 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
     private static final float SEARCH_BAR_HEIGHT = 18;
     private static final float SEARCH_BAR_WIDTH = 140;
     private static final float SEARCH_BAR_MARGIN = 8;
+    private static final float HEADER_BUTTON_SPACING = 6;
+    private static final float HEADER_INVITE_ALL_GAP = 14;
+    private static final float HEADER_MANAGE_BUTTON_W = 88;
+    private static final float HEADER_INVITE_BUTTON_W = 56;
+    private static final float HEADER_OPEN_CLOSE_BUTTON_W = 84;
+    private static final float HEADER_DELIST_BUTTON_W = 72;
+    private static final float HEADER_INVITE_ALL_BUTTON_W = 68;
+    private static final float HEADER_NEW_PARTY_BUTTON_W = 80;
+    private static final float HEADER_ROLE_DROPDOWN_W = 80;
     private static final float SCROLL_SPEED = 12;
     private static final long LOADING_NAME_REFRESH_MS = 1500L;
 
@@ -80,9 +90,9 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
     private static final float FILTER_BUTTON_W = 70;
     private static final float FILTER_BUTTON_H = 24;
     private static final float FILTER_BUTTON_MARGIN = 12;
-    private static final float ERROR_POPUP_MIN_W = 280;
-    private static final float ERROR_POPUP_H = 26;
-    private static final long ERROR_POPUP_DURATION_MS = 3500L;
+    private static final float STATUS_BANNER_MIN_W = 280;
+    private static final float STATUS_BANNER_H = 26;
+    private static final long STATUS_BANNER_DURATION_MS = 3500L;
 
     // Leader management icon sizes
     private static final float LEADER_ICON_SIZE = 14;
@@ -281,8 +291,8 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
     private float hoveredPromoteIconY = -1;
     private float hoveredKickIconX = -1;
     private float hoveredKickIconY = -1;
-    private String activeErrorPopupMessage;
-    private long activeErrorPopupExpiresAtMs;
+    private String activeStatusBannerMessage;
+    private long activeStatusBannerExpiresAtMs;
 
     private static class TagChipHitbox {
         private final String tag;
@@ -302,6 +312,20 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         private boolean contains(float mx, float my) {
             return mx >= x && mx <= x + w && my >= y && my <= y + h;
         }
+    }
+
+    private record HeaderButtonBounds(float x, float y, float w, float h) {
+    }
+
+    private record HeaderControlsLayout(
+            HeaderButtonBounds searchBar,
+            HeaderButtonBounds manageButton,
+            HeaderButtonBounds inviteButton,
+            HeaderButtonBounds openCloseButton,
+            HeaderButtonBounds delistButton,
+            HeaderButtonBounds inviteAllButton,
+            HeaderButtonBounds newPartyButton,
+            HeaderButtonBounds roleDropdown) {
     }
 
     public PartyFinderScreen(Screen parent) {
@@ -499,7 +523,7 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
                         screenHeight);
             }
 
-            renderErrorPopup(nvg, fontName, panelX, panelWidth, screenHeight);
+            renderStatusBanner(nvg, fontName, panelX, panelWidth, screenHeight);
         });
     }
 
@@ -508,56 +532,67 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         super.tick();
         String managerError = party().consumeLatestPartyError();
         if (managerError != null && !managerError.isBlank()) {
-            showErrorPopup(managerError);
+            showStatusBanner(managerError);
         }
         maybeRefreshForLoadingNames();
     }
 
-    private void showErrorPopup(String message) {
-        activeErrorPopupMessage = message;
-        activeErrorPopupExpiresAtMs = System.currentTimeMillis() + ERROR_POPUP_DURATION_MS;
+    private void showStatusBanner(String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        activeStatusBannerMessage = message;
+        activeStatusBannerExpiresAtMs = System.currentTimeMillis() + STATUS_BANNER_DURATION_MS;
     }
 
-    private void renderErrorPopup(
+    private void showErrorPopup(String message) {
+        showStatusBanner(message);
+    }
+
+    private void renderStatusBanner(
             long nvg,
             String fontName,
             float panelX,
             float panelWidth,
             float screenHeight) {
-        if (activeErrorPopupMessage == null || activeErrorPopupMessage.isBlank()) {
+        if (activeStatusBannerMessage == null || activeStatusBannerMessage.isBlank()) {
             return;
         }
 
         long now = System.currentTimeMillis();
-        if (now >= activeErrorPopupExpiresAtMs) {
-            activeErrorPopupMessage = null;
+        if (now >= activeStatusBannerExpiresAtMs) {
+            activeStatusBannerMessage = null;
             return;
         }
 
         nvgFontFace(nvg, fontName);
         nvgFontSize(nvg, 12);
         float[] bounds = new float[4];
-        float textW = nvgTextBounds(nvg, 0, 0, activeErrorPopupMessage, bounds);
+        float textW = nvgTextBounds(nvg, 0, 0, activeStatusBannerMessage, bounds);
         float maxPopupW = Math.max(180f, panelWidth - 20f);
-        float popupW = Math.min(maxPopupW, Math.max(ERROR_POPUP_MIN_W, textW + 28f));
+        float popupW = Math.min(maxPopupW, Math.max(STATUS_BANNER_MIN_W, textW + 28f));
 
         float popupX = panelX + (panelWidth - popupW) / 2f;
-        float popupY = screenHeight - ERROR_POPUP_H - 10;
+        float popupY = screenHeight - STATUS_BANNER_H - 10;
 
-        NVGWrapper.drawRoundedRect(nvg, popupX, popupY, popupW, ERROR_POPUP_H, 6, ERROR_POPUP_BG);
+        NVGWrapper.drawRoundedRect(nvg, popupX, popupY, popupW, STATUS_BANNER_H, 6, ERROR_POPUP_BG);
         NVGWrapper.drawRectOutline(
                 nvg,
                 popupX,
                 popupY,
                 popupW,
-                ERROR_POPUP_H,
+                STATUS_BANNER_H,
                 1,
                 ERROR_POPUP_BORDER);
 
         nvgTextAlign(nvg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
         var text = NVGContext.nvgColor(TEXT_COLOR);
         nvgFillColor(nvg, text);
-        nvgText(nvg, popupX + popupW / 2f, popupY + ERROR_POPUP_H / 2f, activeErrorPopupMessage);
+        nvgText(
+                nvg,
+                popupX + popupW / 2f,
+                popupY + STATUS_BANNER_H / 2f,
+                activeStatusBannerMessage);
         text.free();
     }
 
@@ -648,24 +683,26 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
             float panelX,
             float panelWidth) {
         searchCursorBlink++;
-        float searchX = panelX + SEARCH_BAR_MARGIN;
-        float searchY = (HEADER_HEIGHT - SEARCH_BAR_HEIGHT) / 2f;
+        HeaderControlsLayout layout = computeHeaderControlsLayout(panelX);
+        HeaderButtonBounds searchBar = layout.searchBar();
+        float searchX = searchBar.x();
+        float searchY = searchBar.y();
 
         Color searchBg = searchFocused ? SEARCH_ACTIVE_BG : SEARCH_BG;
         NVGWrapper.drawRect(
                 nvg,
                 searchX,
                 searchY,
-                SEARCH_BAR_WIDTH,
-                SEARCH_BAR_HEIGHT,
+                searchBar.w(),
+                searchBar.h(),
                 searchBg);
         if (searchFocused) {
             NVGWrapper.drawRectOutline(
                     nvg,
                     searchX,
                     searchY,
-                    SEARCH_BAR_WIDTH,
-                    SEARCH_BAR_HEIGHT,
+                    searchBar.w(),
+                    searchBar.h(),
                     1,
                     SEARCH_BORDER);
         }
@@ -675,7 +712,7 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         nvgTextAlign(nvg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
 
         nvgSave(nvg);
-        nvgScissor(nvg, searchX, searchY, SEARCH_BAR_WIDTH, SEARCH_BAR_HEIGHT);
+        nvgScissor(nvg, searchX, searchY, searchBar.w(), searchBar.h());
         if (searchQuery.isEmpty() && !searchFocused) {
             var ph = NVGContext.nvgColor(SEARCH_PLACEHOLDER);
             nvgFillColor(nvg, ph);
@@ -709,69 +746,50 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
                     searchX + 6 + textW + 1,
                     searchY + 3,
                     1,
-                    SEARCH_BAR_HEIGHT - 6,
+                    searchBar.h() - 6,
                     TEXT_COLOR);
         }
-
-        float btnX = searchX + SEARCH_BAR_WIDTH + SEARCH_BAR_MARGIN;
-        float btnY = searchY;
 
         if (party().isPartyLeader()) {
             String manageLabel = party().hasListedParty()
                     ? "Manage Party"
                     : "New party +";
-            float manageW = 88;
             drawHeaderButton(
                     nvg,
                     fontName,
-                    btnX,
-                    btnY,
-                    manageW,
-                    SEARCH_BAR_HEIGHT,
+                    layout.manageButton(),
                     manageLabel,
                     MANAGE_PARTY_COLOR,
                     NEW_PARTY_HOVER);
-            btnX += manageW + 6;
-
-            float inviteW = 56;
             drawHeaderButton(
                     nvg,
                     fontName,
-                    btnX,
-                    btnY,
-                    inviteW,
-                    SEARCH_BAR_HEIGHT,
+                    layout.inviteButton(),
                     "Invite",
                     NEW_PARTY_COLOR,
                     NEW_PARTY_HOVER);
-            btnX += inviteW + 6;
-
-            float openCloseW = 84;
             String openCloseLabel = isCurrentListingClosed() ? "Open party" : "Close party";
             drawHeaderButton(
                     nvg,
                     fontName,
-                    btnX,
-                    btnY,
-                    openCloseW,
-                    SEARCH_BAR_HEIGHT,
+                    layout.openCloseButton(),
                     openCloseLabel,
                     OPEN_CLOSE_PARTY_COLOR,
                     OPEN_CLOSE_PARTY_HOVER);
-            btnX += openCloseW + 6;
-
-            float delistW = 72;
             drawHeaderButton(
                     nvg,
                     fontName,
-                    btnX,
-                    btnY,
-                    delistW,
-                    SEARCH_BAR_HEIGHT,
+                    layout.delistButton(),
                     "Delist party",
                     DELIST_PARTY_COLOR,
                     DELIST_PARTY_HOVER);
-            btnX += delistW + 6;
+            drawHeaderButton(
+                    nvg,
+                    fontName,
+                    layout.inviteAllButton(),
+                    "Invite all",
+                    NEW_PARTY_COLOR,
+                    NEW_PARTY_HOVER);
         } else {
             boolean inPartyAsMember = party().getJoinedPartyIndex() >= 0;
             Color newBg = inPartyAsMember
@@ -783,27 +801,19 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
             drawHeaderButton(
                     nvg,
                     fontName,
-                    btnX,
-                    btnY,
-                    80,
-                    SEARCH_BAR_HEIGHT,
+                    layout.newPartyButton(),
                     "New party +",
                     newBg,
                     newHover);
-            btnX += 86;
         }
 
-        float dropW = 80;
-        dropdownRenderX = btnX;
-        dropdownRenderY = btnY;
-        dropdownRenderW = dropW;
+        dropdownRenderX = layout.roleDropdown().x();
+        dropdownRenderY = layout.roleDropdown().y();
+        dropdownRenderW = layout.roleDropdown().w();
         renderRoleDropdownButton(
                 nvg,
                 fontName,
-                btnX,
-                btnY,
-                dropW,
-                SEARCH_BAR_HEIGHT);
+                layout.roleDropdown());
     }
 
     private void drawHeaderButton(
@@ -828,15 +838,115 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         c.free();
     }
 
+    private void drawHeaderButton(
+            long nvg,
+            String fontName,
+            HeaderButtonBounds bounds,
+            String label,
+            Color bg,
+            Color hoverBg) {
+        if (bounds == null) {
+            return;
+        }
+        drawHeaderButton(
+                nvg,
+                fontName,
+                bounds.x(),
+                bounds.y(),
+                bounds.w(),
+                bounds.h(),
+                label,
+                bg,
+                hoverBg);
+    }
+
+    private HeaderControlsLayout computeHeaderControlsLayout(float panelX) {
+        float searchX = panelX + SEARCH_BAR_MARGIN;
+        float searchY = (HEADER_HEIGHT - SEARCH_BAR_HEIGHT) / 2f;
+        HeaderButtonBounds searchBar = new HeaderButtonBounds(
+                searchX,
+                searchY,
+                SEARCH_BAR_WIDTH,
+                SEARCH_BAR_HEIGHT);
+
+        float nextButtonX = searchX + SEARCH_BAR_WIDTH + SEARCH_BAR_MARGIN;
+        HeaderButtonBounds manageButton = null;
+        HeaderButtonBounds inviteButton = null;
+        HeaderButtonBounds openCloseButton = null;
+        HeaderButtonBounds delistButton = null;
+        HeaderButtonBounds inviteAllButton = null;
+        HeaderButtonBounds newPartyButton = null;
+
+        if (party().isPartyLeader()) {
+            manageButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_MANAGE_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_MANAGE_BUTTON_W + HEADER_BUTTON_SPACING;
+
+            inviteButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_INVITE_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_INVITE_BUTTON_W + HEADER_BUTTON_SPACING;
+
+            openCloseButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_OPEN_CLOSE_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_OPEN_CLOSE_BUTTON_W + HEADER_BUTTON_SPACING;
+
+            delistButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_DELIST_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_DELIST_BUTTON_W + HEADER_INVITE_ALL_GAP;
+
+            inviteAllButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_INVITE_ALL_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_INVITE_ALL_BUTTON_W + HEADER_BUTTON_SPACING;
+        } else {
+            newPartyButton = new HeaderButtonBounds(
+                    nextButtonX,
+                    searchY,
+                    HEADER_NEW_PARTY_BUTTON_W,
+                    SEARCH_BAR_HEIGHT);
+            nextButtonX += HEADER_NEW_PARTY_BUTTON_W + HEADER_BUTTON_SPACING;
+        }
+
+        HeaderButtonBounds roleDropdown = new HeaderButtonBounds(
+                nextButtonX,
+                searchY,
+                HEADER_ROLE_DROPDOWN_W,
+                SEARCH_BAR_HEIGHT);
+        return new HeaderControlsLayout(
+                searchBar,
+                manageButton,
+                inviteButton,
+                openCloseButton,
+                delistButton,
+                inviteAllButton,
+                newPartyButton,
+                roleDropdown);
+    }
+
     // ── Role dropdown ──
 
     private void renderRoleDropdownButton(
             long nvg,
             String fontName,
-            float x,
-            float y,
-            float w,
-            float h) {
+            HeaderButtonBounds bounds) {
+        float x = bounds.x();
+        float y = bounds.y();
+        float w = bounds.w();
+        float h = bounds.h();
         boolean hovered = isHovered(nvgMouseX, nvgMouseY, x, y, w, h);
         NVGWrapper.drawRect(
                 nvg,
@@ -2265,6 +2375,10 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         return mx >= bx && mx <= bx + bw && my >= by && my <= by + bh;
     }
 
+    private boolean isHovered(float mx, float my, HeaderButtonBounds bounds) {
+        return bounds != null && isHovered(mx, my, bounds.x(), bounds.y(), bounds.w(), bounds.h());
+    }
+
     // ══════════════════════════════ INPUT ══════════════════════════════
 
     @Override
@@ -2359,16 +2473,9 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
         // ── Header ──
         float panelX = SIDEBAR_WIDTH;
         float panelWidth = screenWidth - SIDEBAR_WIDTH;
+        HeaderControlsLayout headerLayout = computeHeaderControlsLayout(panelX);
 
-        float searchX = panelX + SEARCH_BAR_MARGIN;
-        float searchY = (HEADER_HEIGHT - SEARCH_BAR_HEIGHT) / 2f;
-        if (isHovered(
-                mx,
-                my,
-                searchX,
-                searchY,
-                SEARCH_BAR_WIDTH,
-                SEARCH_BAR_HEIGHT)) {
+        if (isHovered(mx, my, headerLayout.searchBar())) {
             searchFocused = true;
             searchCursorBlink = 0;
             return true;
@@ -2376,44 +2483,16 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
             searchFocused = false;
         }
 
-        float headerBtnX = searchX + SEARCH_BAR_WIDTH + SEARCH_BAR_MARGIN;
-        float headerBtnY = searchY;
-
         if (party().isPartyLeader()) {
-            float manageW = 88;
-            if (isHovered(
-                    mx,
-                    my,
-                    headerBtnX,
-                    headerBtnY,
-                    manageW,
-                    SEARCH_BAR_HEIGHT)) {
+            if (isHovered(mx, my, headerLayout.manageButton())) {
                 openModal(true);
                 return true;
             }
-            headerBtnX += manageW + 6;
-
-            float inviteW = 56;
-            if (isHovered(
-                    mx,
-                    my,
-                    headerBtnX,
-                    headerBtnY,
-                    inviteW,
-                    SEARCH_BAR_HEIGHT)) {
+            if (isHovered(mx, my, headerLayout.inviteButton())) {
                 openInviteModal();
                 return true;
             }
-            headerBtnX += inviteW + 6;
-
-            float openCloseW = 84;
-            if (isHovered(
-                    mx,
-                    my,
-                    headerBtnX,
-                    headerBtnY,
-                    openCloseW,
-                    SEARCH_BAR_HEIGHT)) {
+            if (isHovered(mx, my, headerLayout.openCloseButton())) {
                 if (party().getCurrentListing() == null) {
                     showErrorPopup("Unable to update party state: no active listing.");
                 } else if (isCurrentListingClosed()) {
@@ -2423,44 +2502,25 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
                 }
                 return true;
             }
-            headerBtnX += openCloseW + 6;
-
-            float delistW = 72;
-            if (isHovered(
-                    mx,
-                    my,
-                    headerBtnX,
-                    headerBtnY,
-                    delistW,
-                    SEARCH_BAR_HEIGHT)) {
+            if (isHovered(mx, my, headerLayout.delistButton())) {
                 party().delistParty();
                 return true;
             }
-            headerBtnX += delistW + 6;
+            if (isHovered(mx, my, headerLayout.inviteAllButton())) {
+                PartyFinderManager.InviteAllResult inviteAllResult = party().inviteAllCurrentMembers();
+                showStatusBanner(inviteAllResult.message());
+                return true;
+            }
         } else {
-            float newW = 80;
-            if (isHovered(
-                    mx,
-                    my,
-                    headerBtnX,
-                    headerBtnY,
-                    newW,
-                    SEARCH_BAR_HEIGHT)) {
+            if (isHovered(mx, my, headerLayout.newPartyButton())) {
                 if (party().getJoinedPartyIndex() < 0) {
                     openModal(false);
                 }
                 return true;
             }
-            headerBtnX += 86;
         }
 
-        if (isHovered(
-                mx,
-                my,
-                dropdownRenderX,
-                dropdownRenderY,
-                dropdownRenderW,
-                SEARCH_BAR_HEIGHT)) {
+        if (isHovered(mx, my, headerLayout.roleDropdown())) {
             roleDropdownOpen = !roleDropdownOpen;
             return true;
         }

--- a/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
+++ b/src/main/java/org/sequoia/seq/ui/PartyFinderScreen.java
@@ -48,7 +48,6 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
     private static final float SEARCH_BAR_WIDTH = 140;
     private static final float SEARCH_BAR_MARGIN = 8;
     private static final float HEADER_BUTTON_SPACING = 6;
-    private static final float HEADER_INVITE_ALL_GAP = 14;
     private static final float HEADER_MANAGE_BUTTON_W = 88;
     private static final float HEADER_INVITE_BUTTON_W = 56;
     private static final float HEADER_OPEN_CLOSE_BUTTON_W = 84;
@@ -904,7 +903,7 @@ public class PartyFinderScreen extends Screen implements PartyAccessor {
                     searchY,
                     HEADER_DELIST_BUTTON_W,
                     SEARCH_BAR_HEIGHT);
-            nextButtonX += HEADER_DELIST_BUTTON_W + HEADER_INVITE_ALL_GAP;
+            nextButtonX += HEADER_DELIST_BUTTON_W + HEADER_BUTTON_SPACING;
 
             inviteAllButton = new HeaderButtonBounds(
                     nextButtonX,

--- a/src/main/java/org/sequoia/seq/utils/PlayerNameCache.java
+++ b/src/main/java/org/sequoia/seq/utils/PlayerNameCache.java
@@ -8,7 +8,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,7 +24,7 @@ public class PlayerNameCache {
 
     private static final Map<String, String> cache = new ConcurrentHashMap<>();
     private static final Map<String, String> usernameToUuid = new ConcurrentHashMap<>();
-    private static final Set<String> pending = ConcurrentHashMap.newKeySet();
+    private static final Map<String, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
     private static final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .build();
@@ -38,90 +37,86 @@ public class PlayerNameCache {
      * list.
      */
     public static String resolve(String uuid) {
-        if (uuid == null)
+        String formattedUuid = formatUUID(uuid);
+        if (formattedUuid == null)
             return "Unknown";
 
-        // 1. Check local player
+        String resolved = resolveImmediate(formattedUuid);
+        if (resolved != null) {
+            return resolved;
+        }
+
+        resolveAsync(formattedUuid);
+        return "Loading...";
+    }
+
+    public static CompletableFuture<String> resolveAsync(String uuid) {
+        String formattedUuid = formatUUID(uuid);
+        if (formattedUuid == null) {
+            return CompletableFuture.completedFuture("Unknown");
+        }
+
+        String resolved = resolveImmediate(formattedUuid);
+        if (resolved != null) {
+            return CompletableFuture.completedFuture(resolved);
+        }
+
+        return pending.computeIfAbsent(formattedUuid, ignored -> CompletableFuture.supplyAsync(() -> {
+            try {
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create(
+                                "https://sessionserver.mojang.com/session/minecraft/profile/"
+                                        + formattedUuid.replace("-", "")))
+                        .timeout(Duration.ofSeconds(10))
+                        .GET()
+                        .build();
+                HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() == 200) {
+                    JsonObject json = GSON.fromJson(resp.body(), JsonObject.class);
+                    if (json != null && json.has("name")) {
+                        String name = json.get("name").getAsString();
+                        put(formattedUuid, name);
+                        return name;
+                    }
+                }
+            } catch (Exception ignoredException) {
+            }
+
+            return null;
+        }).whenComplete((resolvedName, throwable) -> pending.remove(formattedUuid)));
+    }
+
+    private static String resolveImmediate(String formattedUuid) {
         var mc = Minecraft.getInstance();
         var localPlayer = mc.player;
-        if (localPlayer != null && localPlayer.getUUID().toString().equals(uuid)) {
+        if (localPlayer != null && localPlayer.getUUID().toString().equals(formattedUuid)) {
             String name = localPlayer.getName() != null
                     ? localPlayer.getName().getString()
                     : "Unknown";
-            cache.put(uuid, name);
-            if (isCanonicalOnlinePlayerUuid(uuid)) {
-                usernameToUuid.put(name.toLowerCase(), uuid);
-            }
+            put(formattedUuid, name);
             return name;
         }
 
-        // 2. Check cache
-        String cached = cache.get(uuid);
-        if (cached != null)
+        String cached = cache.get(formattedUuid);
+        if (cached != null) {
             return cached;
+        }
 
-        // 3. Check tab list
         var connection = mc.getConnection();
         if (connection != null) {
             try {
-                String formattedUuid = formatUUID(uuid);
-                if (formattedUuid == null) {
-                    return "Loading...";
-                }
                 UUID uid = UUID.fromString(formattedUuid);
                 PlayerInfo info = connection.getPlayerInfo(uid);
                 if (info != null && info.getProfile().name() != null) {
                     String name = info.getProfile().name();
-                    cache.put(uuid, name);
-                    String formattedTabUuid = formatUUID(uuid);
-                    if (isCanonicalOnlinePlayerUuid(formattedTabUuid)) {
-                        usernameToUuid.put(name.toLowerCase(), formattedTabUuid);
-                    }
+                    put(formattedUuid, name);
                     return name;
                 }
             } catch (IllegalArgumentException ignored) {
             }
         }
 
-        // 4. Start async Mojang API lookup if not already pending
-        if (pending.add(uuid)) {
-            CompletableFuture.runAsync(() -> {
-                try {
-                    String cleanUUID = uuid.replace("-", "");
-                    HttpRequest req = HttpRequest.newBuilder()
-                            .uri(
-                                    URI.create(
-                                            "https://sessionserver.mojang.com/session/minecraft/profile/" +
-                                                    cleanUUID))
-                            .timeout(Duration.ofSeconds(10))
-                            .GET()
-                            .build();
-                    HttpResponse<String> resp = httpClient.send(
-                            req,
-                            HttpResponse.BodyHandlers.ofString());
-                    if (resp.statusCode() == 200) {
-                        JsonObject json = GSON.fromJson(
-                                resp.body(),
-                                JsonObject.class);
-                        if (json.has("name")) {
-                            String name = json.get("name").getAsString();
-                            String formatted = formatUUID(uuid);
-                            cache.put(formatted, name);
-                            if (isCanonicalOnlinePlayerUuid(formatted)) {
-                                usernameToUuid.put(name.toLowerCase(), formatted);
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    // Lookup failed — will retry next time resolve() is called
-                } finally {
-                    pending.remove(uuid);
-                }
-            });
-        }
-
-        // 5. Fallback while async resolution is in progress
-        return "Loading...";
+        return null;
     }
 
     /**
@@ -131,9 +126,25 @@ public class PlayerNameCache {
     public static String formatUUID(String uuid) {
         if (uuid == null)
             return null;
-        if (uuid.contains("-"))
-            return uuid;
-        return uuid.replaceFirst(
+
+        String trimmed = uuid.trim();
+        if (trimmed.isBlank()) {
+            return null;
+        }
+
+        if (trimmed.contains("-")) {
+            try {
+                return UUID.fromString(trimmed).toString();
+            } catch (IllegalArgumentException ignored) {
+                return null;
+            }
+        }
+
+        if (!trimmed.matches("[0-9a-fA-F]{32}")) {
+            return null;
+        }
+
+        return trimmed.replaceFirst(
                 "(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})",
                 "$1-$2-$3-$4-$5");
     }

--- a/src/main/java/org/sequoia/seq/utils/PlayerNameCache.java
+++ b/src/main/java/org/sequoia/seq/utils/PlayerNameCache.java
@@ -7,6 +7,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -153,9 +154,12 @@ public class PlayerNameCache {
     public static void put(String uuid, String username) {
         if (uuid != null && username != null) {
             String formatted = formatUUID(uuid);
+            if (formatted == null) {
+                return;
+            }
             cache.put(formatted, username);
             if (isCanonicalOnlinePlayerUuid(formatted)) {
-                usernameToUuid.put(username.toLowerCase(), formatted);
+                usernameToUuid.put(username.toLowerCase(Locale.ROOT), formatted);
             }
         }
     }
@@ -170,7 +174,7 @@ public class PlayerNameCache {
         }
 
         String normalized = username.trim();
-        String key = normalized.toLowerCase();
+        String key = normalized.toLowerCase(Locale.ROOT);
 
         String cachedUuid = usernameToUuid.get(key);
         if (cachedUuid != null && !cachedUuid.isBlank()) {
@@ -202,7 +206,7 @@ public class PlayerNameCache {
                 }
 
                 String name = info.getProfile().name();
-                if (name.equalsIgnoreCase(normalized)) {
+                if (name != null && name.equalsIgnoreCase(normalized)) {
                     String resolved = info.getProfile().id() != null
                             ? info.getProfile().id().toString()
                             : null;


### PR DESCRIPTION
## Summary
- add a full `/seq p` alias and command-first Sequoia party management, including separate Wynn party subcommands
- route invite actions through client commands and improve invite feedback, sender resolution, and reserved-slot guidance
- expose activity alias metadata and manager helpers for command parsing, listing refreshes, and party updates