### PR TITLE
test(auto-update): add Windows updater coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,29 @@ jobs:
 
       - name: Build
         run: ./gradlew clean build remapJar --stacktrace
+
+  windows-updater-tests:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Run updater tests on Windows
+        run: .\gradlew.bat test --tests org.sequoia.seq.update.UpdateManagerTest --tests org.sequoia.seq.update.UpdateApplierTest --stacktrace
+
+      - name: Upload Windows updater test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-updater-test-reports
+          path: |
+            build/reports/tests/test
+            build/test-results/test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - "v*"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ atlassian-ide-plugin.xml
 
 # Log file
 *.log
+logs/*.log.gz
 
 # BlueJ files
 *.ctxt

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ version = project.mod_version
 group = project.maven_group
 
 def sanitizedArchiveVersion = project.version.toString().replaceFirst(/^v/, "")
+def requestedTaskNames = gradle.startParameter.taskNames.collect { it.toLowerCase(Locale.ROOT) }
+def enableDevAuth = providers.gradleProperty("enable_devauth")
+        .map { it.toBoolean() }
+        .orElse(!providers.environmentVariable("CI").isPresent()
+                && requestedTaskNames.any { it.contains("runclient") })
+        .get()
 
 base {
     archivesName = project.archives_base_name
@@ -99,10 +105,11 @@ dependencies {
     include(implementation("org.lwjgl:lwjgl-nanovg::natives-windows-x86"))
     include(implementation("org.lwjgl:lwjgl-nanovg::natives-windows-arm64"))
 
-    //devauth
-    modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:1.2.1")
-    // Needed for DevAuth: provides org.apache.http.client.methods.HttpUriRequest
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    if (enableDevAuth) {
+        modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:1.2.1")
+        // Needed for DevAuth: provides org.apache.http.client.methods.HttpUriRequest
+        implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    }
 
     // WebSocket client
     include(implementation("org.java-websocket:Java-WebSocket:1.6.0"))

--- a/src/main/java/org/sequoia/seq/update/UpdateApplier.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateApplier.java
@@ -10,6 +10,9 @@ import java.util.stream.Stream;
  * Args: modsDir currentJar pendingJar finalJar helperJar
  */
 public final class UpdateApplier {
+    private static final int DEFAULT_RETRY_ATTEMPTS = 40;
+    private static final long DEFAULT_RETRY_DELAY_MILLIS = 1500;
+
     private UpdateApplier() {
     }
 
@@ -24,22 +27,34 @@ public final class UpdateApplier {
         Path finalJar = Path.of(args[3]);
         Path helperJar = Path.of(args[4]);
 
-        boolean installed = applyWithRetries(modsDir, currentJar, pendingJar, finalJar);
+        run(modsDir, currentJar, pendingJar, finalJar, helperJar, DEFAULT_RETRY_ATTEMPTS, DEFAULT_RETRY_DELAY_MILLIS);
+    }
+
+    static void run(
+            Path modsDir,
+            Path currentJar,
+            Path pendingJar,
+            Path finalJar,
+            Path helperJar,
+            int retryAttempts,
+            long retryDelayMillis) {
+        boolean installed = applyWithRetries(modsDir, currentJar, pendingJar, finalJar, retryAttempts, retryDelayMillis);
         if (installed) {
             deleteQuietly(pendingJar);
         }
         deleteQuietly(helperJar);
     }
 
-    private static boolean applyWithRetries(Path modsDir, Path currentJar, Path pendingJar, Path finalJar) {
-        for (int attempt = 0; attempt < 40; attempt++) {
+    static boolean applyWithRetries(
+            Path modsDir, Path currentJar, Path pendingJar, Path finalJar, int retryAttempts, long retryDelayMillis) {
+        for (int attempt = 0; attempt < retryAttempts; attempt++) {
             try {
                 deleteReplacedJar(currentJar, finalJar);
                 Files.move(pendingJar, finalJar, StandardCopyOption.REPLACE_EXISTING);
                 deleteStaleSequoiaJars(modsDir, finalJar);
                 return true;
             } catch (Exception ignored) {
-                sleep(1500);
+                sleep(retryDelayMillis);
             }
         }
         return false;

--- a/src/main/java/org/sequoia/seq/update/UpdateApplier.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateApplier.java
@@ -3,6 +3,7 @@ package org.sequoia.seq.update;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 /**
@@ -42,7 +43,7 @@ public final class UpdateApplier {
         if (installed) {
             deleteQuietly(pendingJar);
         }
-        deleteQuietly(helperJar);
+        cleanupHelperJar(helperJar);
     }
 
     static boolean applyWithRetries(
@@ -80,6 +81,28 @@ public final class UpdateApplier {
     private static void deleteQuietly(Path path) {
         try {
             Files.deleteIfExists(path);
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void cleanupHelperJar(Path helperJar) {
+        deleteQuietly(helperJar);
+        if (Files.exists(helperJar) && isWindows()) {
+            scheduleWindowsDelete(helperJar);
+        }
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private static void scheduleWindowsDelete(Path path) {
+        try {
+            new ProcessBuilder(
+                            "cmd.exe",
+                            "/c",
+                            "ping 127.0.0.1 -n 3 > nul && del /f /q \"" + path + "\"")
+                    .start();
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/org/sequoia/seq/update/UpdateManager.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateManager.java
@@ -365,10 +365,14 @@ public class UpdateManager implements NotificationAccessor {
         if (!shutdownHookRegistered.compareAndSet(false, true)) {
             return;
         }
-        Runtime.getRuntime().addShutdownHook(new Thread(this::applyPendingInstallOnShutdown, "seq-update-shutdown"));
+        addShutdownHook(new Thread(this::applyPendingInstallOnShutdown, "seq-update-shutdown"));
     }
 
-    private void applyPendingInstallOnShutdown() {
+    void addShutdownHook(Thread thread) {
+        Runtime.getRuntime().addShutdownHook(thread);
+    }
+
+    void applyPendingInstallOnShutdown() {
         PendingInstall install = pendingInstall;
         if (install == null || !Files.exists(install.pendingJar())) {
             return;
@@ -399,18 +403,13 @@ public class UpdateManager implements NotificationAccessor {
             Path helperJar = updatesDir.resolve("seq-update-helper.jar");
             Files.copy(sourceJar, helperJar, StandardCopyOption.REPLACE_EXISTING);
 
-            String javaExe = resolveJavaExecutable();
-            new ProcessBuilder(
-                            javaExe,
-                            "-cp",
-                            helperJar.toString(),
-                            UpdateApplier.class.getName(),
-                            install.modsDir().toString(),
-                        install.currentJar().toString(),
-                            install.pendingJar().toString(),
-                            install.finalJar().toString(),
-                            helperJar.toString())
-                    .start();
+            launchUpdateHelperProcess(
+                    resolveJavaExecutable(),
+                    helperJar,
+                    install.modsDir(),
+                    install.currentJar(),
+                    install.pendingJar(),
+                    install.finalJar());
 
             SeqClient.LOGGER.info("Launched Windows update helper for {}", install.tagName());
         } catch (Exception e) {
@@ -418,7 +417,23 @@ public class UpdateManager implements NotificationAccessor {
         }
     }
 
-    private Path resolveCurrentModJarPath() {
+    void launchUpdateHelperProcess(
+            String javaExe, Path helperJar, Path modsDir, Path currentJar, Path pendingJar, Path finalJar)
+            throws IOException {
+        new ProcessBuilder(
+                        javaExe,
+                        "-cp",
+                        helperJar.toString(),
+                        UpdateApplier.class.getName(),
+                        modsDir.toString(),
+                        currentJar.toString(),
+                        pendingJar.toString(),
+                        finalJar.toString(),
+                        helperJar.toString())
+                .start();
+    }
+
+    Path resolveCurrentModJarPath() {
         try {
             URI location = UpdateManager.class
                     .getProtectionDomain()
@@ -436,7 +451,7 @@ public class UpdateManager implements NotificationAccessor {
         }
     }
 
-    private String resolveJavaExecutable() {
+    String resolveJavaExecutable() {
         String javaHome = System.getProperty("java.home");
         if (javaHome != null && !javaHome.isBlank()) {
             Path javaExe = Path.of(javaHome, "bin", "java.exe");
@@ -550,7 +565,7 @@ public class UpdateManager implements NotificationAccessor {
         }
     }
 
-    private String resolveInstalledVersion() {
+    String resolveInstalledVersion() {
         return FabricLoader.getInstance()
                 .getModContainer(MOD_ID)
                 .map(container -> container.getMetadata().getVersion().getFriendlyString())
@@ -657,5 +672,5 @@ public class UpdateManager implements NotificationAccessor {
         }
     }
 
-    private record PendingInstall(Path pendingJar, Path finalJar, Path modsDir, String tagName, Path currentJar) {}
+    record PendingInstall(Path pendingJar, Path finalJar, Path modsDir, String tagName, Path currentJar) {}
 }

--- a/src/test/java/org/sequoia/seq/update/UpdateApplierTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateApplierTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class UpdateApplierTest {
 
     @Test
-    void mainDeletesCurrentJarAndInstallsPendingJar(@TempDir Path tempDir) throws Exception {
+    void mainDeletesCurrentJarInstallsPendingJarAndRemovesStaleVersions(@TempDir Path tempDir) throws Exception {
         Path modsDir = tempDir.resolve("mods");
         Path updatesDir = tempDir.resolve("updates");
         Files.createDirectories(modsDir);
@@ -22,12 +22,14 @@ class UpdateApplierTest {
 
         Path currentJar = modsDir.resolve("sequoia-0.0.1.jar");
         Path staleJar = modsDir.resolve("sequoia-0.0.0.jar");
+        Path unrelatedJar = modsDir.resolve("othermod.jar");
         Path finalJar = modsDir.resolve("sequoia-0.0.2.jar");
         Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
         Path helperJar = updatesDir.resolve("seq-update-helper.jar");
 
         Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
         Files.writeString(staleJar, "stale", StandardCharsets.UTF_8);
+        Files.writeString(unrelatedJar, "keep", StandardCharsets.UTF_8);
         byte[] pendingBytes = "pending".getBytes(StandardCharsets.UTF_8);
         Files.write(pendingJar, pendingBytes);
         Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
@@ -44,7 +46,77 @@ class UpdateApplierTest {
         assertArrayEquals(pendingBytes, Files.readAllBytes(finalJar));
         assertFalse(Files.exists(currentJar));
         assertFalse(Files.exists(staleJar));
+        assertTrue(Files.exists(unrelatedJar));
         assertFalse(Files.exists(pendingJar));
+        assertFalse(Files.exists(helperJar));
+    }
+
+    @Test
+    void mainReturnsImmediatelyWhenArgsAreMissing(@TempDir Path tempDir) throws Exception {
+        Path helperJar = tempDir.resolve("seq-update-helper.jar");
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+
+        UpdateApplier.main(new String[] {tempDir.toString(), helperJar.toString(), tempDir.toString()});
+
+        assertTrue(Files.exists(helperJar));
+    }
+
+    @Test
+    void mainReplacesCurrentJarInPlaceWhenCurrentAndFinalMatch(@TempDir Path tempDir) throws Exception {
+        Path modsDir = tempDir.resolve("mods");
+        Path updatesDir = tempDir.resolve("updates");
+        Files.createDirectories(modsDir);
+        Files.createDirectories(updatesDir);
+
+        Path currentJar = modsDir.resolve("sequoia-0.0.2.jar");
+        Path staleJar = modsDir.resolve("sequoia-0.0.1.jar");
+        Path unrelatedJar = modsDir.resolve("othermod.jar");
+        Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
+        Path helperJar = updatesDir.resolve("seq-update-helper.jar");
+
+        Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
+        Files.writeString(staleJar, "stale", StandardCharsets.UTF_8);
+        Files.writeString(unrelatedJar, "keep", StandardCharsets.UTF_8);
+        byte[] pendingBytes = "pending".getBytes(StandardCharsets.UTF_8);
+        Files.write(pendingJar, pendingBytes);
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+
+        UpdateApplier.main(new String[] {
+                modsDir.toString(),
+                currentJar.toString(),
+                pendingJar.toString(),
+                currentJar.toString(),
+                helperJar.toString()
+        });
+
+        assertTrue(Files.exists(currentJar));
+        assertArrayEquals(pendingBytes, Files.readAllBytes(currentJar));
+        assertFalse(Files.exists(staleJar));
+        assertTrue(Files.exists(unrelatedJar));
+        assertFalse(Files.exists(pendingJar));
+        assertFalse(Files.exists(helperJar));
+    }
+
+    @Test
+    void mainLeavesPendingJarInPlaceWhenInstallNeverSucceeds(@TempDir Path tempDir) throws Exception {
+        Path modsDir = tempDir.resolve("mods");
+        Path updatesDir = tempDir.resolve("updates");
+        Files.createDirectories(modsDir);
+        Files.createDirectories(updatesDir);
+
+        Path currentJar = modsDir.resolve("sequoia-0.0.1.jar");
+        Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
+        Path helperJar = updatesDir.resolve("seq-update-helper.jar");
+        Path finalJar = tempDir.resolve("missing").resolve("sequoia-0.0.2.jar");
+
+        Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+        Files.writeString(pendingJar, "pending", StandardCharsets.UTF_8);
+
+        UpdateApplier.run(modsDir, currentJar, pendingJar, finalJar, helperJar, 2, 0);
+
+        assertFalse(Files.exists(finalJar));
+        assertTrue(Files.exists(pendingJar));
         assertFalse(Files.exists(helperJar));
     }
 }

--- a/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
@@ -758,9 +758,13 @@ class UpdateManagerTest {
             Path helperJar = gameDir.resolve("updates").resolve("seq-update-helper.jar");
 
             awaitCondition(
-                    () -> Files.exists(finalJar) && !Files.exists(pendingJar) && !Files.exists(helperJar),
+                    () -> Files.exists(finalJar) && !Files.exists(pendingJar),
                     20,
-                    "Timed out waiting for the Windows helper process to finish.");
+                    "Timed out waiting for the Windows helper process to install the update.");
+            awaitCondition(
+                    () -> !Files.exists(helperJar),
+                    10,
+                    "Timed out waiting for the Windows helper process to clean up its helper jar.");
 
             assertEquals(1, manager.helperLaunches.size());
             assertArrayEquals(jarBytes, Files.readAllBytes(finalJar));

--- a/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
@@ -4,9 +4,12 @@ import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -15,20 +18,34 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
-import java.util.ArrayList;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UpdateManagerTest {
+    private static final URI UNUSED_RELEASES_API = URI.create("https://example.invalid/releases/latest");
 
     @Test
     void isNewerComparesStrictVersionTags() {
@@ -41,72 +58,296 @@ class UpdateManagerTest {
 
     @Test
     void parseChecksumAcceptsSha256FileFormat() {
-        String checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        String checksum = checksumValue();
 
         assertEquals(checksum, UpdateManager.parseChecksum(checksum + "  sequoia.jar\n"));
     }
 
     @Test
+    void parseChecksumRejectsEmptyFile() {
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> UpdateManager.parseChecksum(" \n "));
+
+        assertEquals("Checksum file was empty.", error.getMessage());
+    }
+
+    @Test
+    void parseChecksumRejectsInvalidFormat() {
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class, () -> UpdateManager.parseChecksum("not-a-checksum  sequoia.jar"));
+
+        assertEquals("Checksum file had invalid format.", error.getMessage());
+    }
+
+    @Test
     void parseSha256DigestAcceptsGitHubDigestFormat() {
-        String checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        String checksum = checksumValue();
 
         assertEquals(checksum, UpdateManager.parseSha256Digest("sha256:" + checksum.toUpperCase()));
     }
 
     @Test
+    void parseSha256DigestRejectsInvalidFormat() {
+        assertNull(UpdateManager.parseSha256Digest("sha256:not-hex"));
+    }
+
+    @Test
     void fetchLatestReleaseParsesJarAndChecksumAssets(@TempDir Path gameDir) throws Exception {
+        String checksum = checksumValue();
+
         try (TestHttpServer server = new TestHttpServer()) {
             server.respondJson("/releases/latest", """
-                            {
-                              "tag_name": "v0.1.1",
-                              "html_url": "https://example.invalid/releases/v0.1.1",
-                              "assets": [
-                                {
-                                  "name": "sequoia-0.1.1.jar",
-                                                                    "browser_download_url": "%s",
-                                                                    "digest": "sha256:%s"
-                                },
-                                {
-                                  "name": "sequoia-0.1.1.jar.sha256",
-                                  "browser_download_url": "%s"
-                                }
-                              ]
-                            }
-                            """.formatted(
-                            server.uri("/downloads/sequoia-0.1.1.jar"),
-                            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-                            server.uri("/downloads/sequoia-0.1.1.jar.sha256")));
+                    {
+                      "tag_name": "v0.1.1",
+                      "html_url": "https://example.invalid/releases/v0.1.1",
+                      "assets": [
+                        {
+                          "name": "sequoia-0.1.1.jar",
+                          "browser_download_url": "%s",
+                          "digest": "sha256:%s"
+                        },
+                        {
+                          "name": "sequoia-0.1.1.jar.sha256",
+                          "browser_download_url": "%s"
+                        }
+                      ]
+                    }
+                    """.formatted(
+                    server.uri("/downloads/sequoia-0.1.1.jar"), checksum, server.uri("/downloads/sequoia-0.1.1.jar.sha256")));
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                TestableUpdateManager manager = new TestableUpdateManager(
-                        HttpClient.newBuilder().executor(executor).build(),
-                        executor,
-                        server.uri("/releases/latest"),
-                        gameDir,
-                        false);
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
 
-                UpdateManager.ReleaseCandidate release =
-                        manager.fetchLatestRelease().join();
+                UpdateManager.ReleaseCandidate release = manager.fetchLatestRelease().join();
 
                 assertNotNull(release);
                 assertEquals("v0.1.1", release.tagName());
                 assertEquals("sequoia-0.1.1.jar", release.jarAsset().name());
-                assertEquals(
-                        server.uri("/downloads/sequoia-0.1.1.jar").toString(),
-                        release.jarAsset().downloadUrl());
-                assertEquals(
-                        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-                        release.jarAsset().sha256());
+                assertEquals(server.uri("/downloads/sequoia-0.1.1.jar").toString(), release.jarAsset().downloadUrl());
+                assertEquals(checksum, release.jarAsset().sha256());
                 assertEquals("sequoia-0.1.1.jar.sha256", release.checksumAsset().name());
-            } finally {
-                executor.shutdownNow();
             }
         }
     }
 
     @Test
-    void applyReleaseInstallsJarAndRemovesPreviousVersion(@TempDir Path gameDir) throws Exception {
+    void fetchLatestReleaseRejectsInvalidTag(@TempDir Path gameDir) throws Exception {
+        assertFetchFailure(gameDir, """
+                {
+                  "tag_name": "latest",
+                  "html_url": "https://example.invalid/releases/latest",
+                  "assets": []
+                }
+                """, "Release has invalid tag name: latest");
+    }
+
+    @Test
+    void fetchLatestReleaseRejectsMissingPrimaryJarAsset(@TempDir Path gameDir) throws Exception {
+        assertFetchFailure(gameDir, """
+                {
+                  "tag_name": "v0.1.1",
+                  "html_url": "https://example.invalid/releases/v0.1.1",
+                  "assets": [
+                    {
+                      "name": "notes.txt",
+                      "browser_download_url": "https://example.invalid/notes.txt"
+                    }
+                  ]
+                }
+                """, "Release missing primary mod jar asset.");
+    }
+
+    @Test
+    void fetchLatestReleaseRejectsMissingChecksumAsset(@TempDir Path gameDir) throws Exception {
+        assertFetchFailure(gameDir, """
+                {
+                  "tag_name": "v0.1.1",
+                  "html_url": "https://example.invalid/releases/v0.1.1",
+                  "assets": [
+                    {
+                      "name": "sequoia-0.1.1.jar",
+                      "browser_download_url": "https://example.invalid/sequoia-0.1.1.jar"
+                    }
+                  ]
+                }
+                """, "Release missing required checksum asset sequoia-0.1.1.jar.sha256.");
+    }
+
+    @Test
+    void fetchLatestReleaseRejectsGitHubApiErrors(@TempDir Path gameDir) throws Exception {
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondStatus("/releases/latest", 503, "unavailable", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                CompletionException error =
+                        assertThrows(CompletionException.class, () -> manager.fetchLatestRelease().join());
+
+                assertEquals("GitHub API returned 503", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void checkForUpdatesOnStartupRunsOnlyOnce(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(null));
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release("v0.2.0")));
+
+        manager.checkForUpdatesOnStartup();
+        manager.checkForUpdatesOnStartup();
+
+        assertEquals(1, manager.fetchCalls.get());
+        assertEquals("No valid release found.", manager.getStatusLine());
+    }
+
+    @Test
+    void checkForUpdatesManualUpToDateNotifiesAndClearsPendingRelease(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        UpdateManager.ReleaseCandidate release = release("v0.1.1");
+
+        manager.installedVersion = "v0.1.0";
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesManually();
+        assertEquals(1, manager.prompts.size());
+
+        manager.installedVersion = "v0.1.1";
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesManually();
+
+        assertEquals("Up to date (v0.1.1).", manager.getStatusLine());
+        assertTrue(manager.notifications.contains("You are up to date (v0.1.1)."));
+
+        manager.openReleasePage();
+        assertEquals(0, manager.browserOpenCount.get());
+    }
+
+    @Test
+    void checkForUpdatesIgnoresSessionTagOnStartupButShowsPromptOnManualCheck(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        UpdateManager.ReleaseCandidate release = release("v0.1.1");
+
+        manager.installedVersion = "v0.1.0";
+        manager.ignoreForSession("v0.1.1");
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesOnStartup();
+
+        assertEquals("Update v0.1.1 ignored for this session.", manager.getStatusLine());
+        assertTrue(manager.prompts.isEmpty());
+
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesManually();
+
+        assertEquals(1, manager.prompts.size());
+        assertEquals("Update available: v0.1.0 -> v0.1.1", manager.getStatusLine());
+    }
+
+    @Test
+    void checkForUpdatesManualFailureNotifiesButStartupFailureDoesNot(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+
+        manager.enqueueFetchResult(CompletableFuture.failedFuture(new IllegalStateException("startup failure")));
+        manager.checkForUpdatesOnStartup();
+        assertTrue(manager.notifications.isEmpty());
+        assertEquals("Update check failed: startup failure", manager.getStatusLine());
+
+        manager.enqueueFetchResult(CompletableFuture.failedFuture(new IllegalStateException("manual failure")));
+        manager.checkForUpdatesManually();
+
+        assertEquals("Update check failed: manual failure", manager.getStatusLine());
+        assertEquals(List.of("Update check failed: manual failure"), manager.notifications);
+    }
+
+    @Test
+    void checkForUpdatesManualNullCandidateNotifies(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(null));
+
+        manager.checkForUpdatesManually();
+
+        assertEquals("No valid release found.", manager.getStatusLine());
+        assertEquals(List.of("No valid release found."), manager.notifications);
+    }
+
+    @Test
+    void checkForUpdatesAlreadyRunningOnlyNotifiesManualCallers(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        CompletableFuture<UpdateManager.ReleaseCandidate> pending = new CompletableFuture<>();
+        manager.enqueueFetchResult(pending);
+
+        manager.checkForUpdatesOnStartup();
+        manager.checkForUpdatesManually();
+
+        assertEquals(List.of("Update check already running."), manager.notifications);
+        assertEquals("Checking for updates...", manager.getStatusLine());
+
+        pending.complete(null);
+        assertEquals("No valid release found.", manager.getStatusLine());
+    }
+
+    @Test
+    void openReleasePageFallsBackToClickableNotificationWhenBrowserFails(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        UpdateManager.ReleaseCandidate release = release("v0.1.1");
+        manager.installedVersion = "v0.1.0";
+        manager.browserShouldFail = true;
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesManually();
+
+        manager.openReleasePage();
+
+        assertEquals(1, manager.browserOpenCount.get());
+        assertEquals(List.of("Open latest release -> https://example.invalid/releases/v0.1.1"), manager.clickableNotifications);
+    }
+
+    @Test
+    void applyPendingUpdateWithoutPendingReleaseNotifies(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+
+        manager.applyPendingUpdate(false);
+
+        assertEquals("No pending update available.", manager.getStatusLine());
+        assertEquals(List.of("No pending update available."), manager.notifications);
+    }
+
+    @Test
+    void applyPendingUpdateReportsFailureAndDoesNotStopMinecraft(@TempDir Path gameDir) {
+        TestableUpdateManager manager = newDirectManager(gameDir);
+        manager.skipRealApply = true;
+        manager.applyFailure = new RuntimeException(new IllegalStateException("install boom"));
+        seedPendingRelease(manager, release("v0.1.1"));
+
+        manager.applyPendingUpdate(true);
+
+        assertEquals("Install failed: install boom", manager.getStatusLine());
+        assertTrue(manager.notifications.contains("Update failed: install boom"));
+        assertEquals(0, manager.stopRequests.get());
+    }
+
+    @Test
+    void applyPendingUpdateRejectsConcurrentInstalls(@TempDir Path gameDir) throws Exception {
+        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            TestableUpdateManager manager = newManager(executor, UNUSED_RELEASES_API, gameDir);
+            manager.skipRealApply = true;
+            manager.applyStarted = new CountDownLatch(1);
+            manager.allowApplyToFinish = new CountDownLatch(1);
+            seedPendingRelease(manager, release("v0.1.1"));
+
+            manager.applyPendingUpdate(false);
+            assertTrue(manager.applyStarted.await(2, TimeUnit.SECONDS));
+
+            manager.applyPendingUpdate(false);
+
+            assertTrue(manager.notifications.contains("Update install already in progress."));
+
+            manager.allowApplyToFinish.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void applyReleaseInstallsJarRemovesPreviousVersionAndPreservesOtherMods(@TempDir Path gameDir) throws Exception {
         byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
         String checksum = sha256(jarBytes);
 
@@ -117,37 +358,22 @@ class UpdateManagerTest {
             Path modsDir = gameDir.resolve("mods");
             Files.createDirectories(modsDir);
             Files.writeString(modsDir.resolve("sequoia-0.1.0.jar"), "old");
+            Files.writeString(modsDir.resolve("othermod.jar"), "keep");
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                TestableUpdateManager manager = new TestableUpdateManager(
-                        HttpClient.newBuilder().executor(executor).build(),
-                        executor,
-                        server.uri("/releases/latest"),
-                        gameDir,
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                manager.applyRelease(
+                        release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
                         false);
-
-                UpdateManager.ReleaseCandidate release = new UpdateManager.ReleaseCandidate(
-                        "v0.1.1",
-                        "https://example.invalid/releases/v0.1.1",
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar",
-                                server.uri("/downloads/sequoia-0.1.1.jar").toString()),
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar.sha256",
-                                server.uri("/downloads/sequoia-0.1.1.jar.sha256")
-                                        .toString()));
-
-                manager.applyRelease(release, false);
 
                 Path installedJar = modsDir.resolve("sequoia-0.1.1.jar");
                 assertTrue(Files.exists(installedJar));
                 assertArrayEquals(jarBytes, Files.readAllBytes(installedJar));
                 assertFalse(Files.exists(modsDir.resolve("sequoia-0.1.0.jar")));
+                assertTrue(Files.exists(modsDir.resolve("othermod.jar")));
                 assertEquals("Installed v0.1.1. Restart required.", manager.getStatusLine());
                 assertEquals(List.of("Installed v0.1.1. Restart Minecraft to load it."), manager.notifications);
-            } finally {
-                executor.shutdownNow();
             }
         }
     }
@@ -163,33 +389,20 @@ class UpdateManagerTest {
                     "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff  sequoia-0.1.1.jar\n",
                     "text/plain");
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                TestableUpdateManager manager = new TestableUpdateManager(
-                        HttpClient.newBuilder().executor(executor).build(),
-                        executor,
-                        server.uri("/releases/latest"),
-                        gameDir,
-                        false);
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
 
-                UpdateManager.ReleaseCandidate release = new UpdateManager.ReleaseCandidate(
-                        "v0.1.1",
-                        "https://example.invalid/releases/v0.1.1",
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar",
-                                server.uri("/downloads/sequoia-0.1.1.jar").toString()),
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar.sha256",
-                                server.uri("/downloads/sequoia-0.1.1.jar.sha256")
-                                        .toString()));
-
-                RuntimeException error =
-                        assertThrows(RuntimeException.class, () -> manager.applyRelease(release, false));
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
 
                 assertEquals("Checksum mismatch for downloaded update.", UpdateManager.rootCauseMessage(error));
                 assertFalse(Files.exists(gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.download")));
-            } finally {
-                executor.shutdownNow();
             }
         }
     }
@@ -208,33 +421,16 @@ class UpdateManagerTest {
             Path modsDir = gameDir.resolve("mods");
             Files.createDirectories(modsDir);
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                TestableUpdateManager manager = new TestableUpdateManager(
-                        HttpClient.newBuilder().executor(executor).build(),
-                        executor,
-                        server.uri("/releases/latest"),
-                        gameDir,
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                manager.applyRelease(
+                        release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
                         false);
-
-                UpdateManager.ReleaseCandidate release = new UpdateManager.ReleaseCandidate(
-                        "v0.1.1",
-                        "https://example.invalid/releases/v0.1.1",
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar",
-                                server.uri("/downloads/sequoia-0.1.1.jar").toString()),
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar.sha256",
-                                server.uri("/downloads/sequoia-0.1.1.jar.sha256")
-                                        .toString()));
-
-                manager.applyRelease(release, false);
 
                 Path installedJar = modsDir.resolve("sequoia-0.1.1.jar");
                 assertTrue(Files.exists(installedJar));
                 assertArrayEquals(jarBytes, Files.readAllBytes(installedJar));
-            } finally {
-                executor.shutdownNow();
             }
         }
     }
@@ -251,36 +447,403 @@ class UpdateManagerTest {
             Path modsDir = gameDir.resolve("mods");
             Files.createDirectories(modsDir);
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                TestableUpdateManager manager = new TestableUpdateManager(
-                        HttpClient.newBuilder().executor(executor).build(),
-                        executor,
-                        server.uri("/releases/latest"),
-                        gameDir,
-                        false);
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
 
-                UpdateManager.ReleaseCandidate release = new UpdateManager.ReleaseCandidate(
-                        "v0.1.1",
-                        "https://example.invalid/releases/v0.1.1",
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar",
-                                server.uri("/downloads/sequoia-0.1.1.jar").toString(),
+                manager.applyRelease(
+                        release(
+                                "v0.1.1",
+                                server.uri("/downloads/sequoia-0.1.1.jar"),
+                                server.uri("/downloads/sequoia-0.1.1.jar.sha256"),
                                 checksum),
-                        new UpdateManager.ReleaseAsset(
-                                "sequoia-0.1.1.jar.sha256",
-                                server.uri("/downloads/sequoia-0.1.1.jar.sha256")
-                                        .toString()));
-
-                manager.applyRelease(release, false);
+                        false);
 
                 Path installedJar = modsDir.resolve("sequoia-0.1.1.jar");
                 assertTrue(Files.exists(installedJar));
                 assertArrayEquals(jarBytes, Files.readAllBytes(installedJar));
-            } finally {
-                executor.shutdownNow();
             }
         }
+    }
+
+    @Test
+    void applyReleaseFailsWhenChecksumFileIsEmptyWithoutEmbeddedDigest(@TempDir Path gameDir) throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", "", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Checksum file was empty.", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyReleaseFailsWhenChecksumFileIsMalformed(@TempDir Path gameDir) throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", "invalid", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Checksum file had invalid format.", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyReleaseFailsWhenJarDownloadRedirectsTooManyTimes(@TempDir Path gameDir) throws Exception {
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.redirect("/downloads/sequoia-0.1.1.jar", "/downloads/sequoia-0.1.1.jar");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksumValue() + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Download failed: too many redirects.", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyReleaseFailsWhenRedirectResponseIsMissingLocationHeader(@TempDir Path gameDir) throws Exception {
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.redirectWithoutLocation("/downloads/sequoia-0.1.1.jar");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksumValue() + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Download redirect missing Location header.", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyReleaseFailsWhenJarDownloadReturnsHttpError(@TempDir Path gameDir) throws Exception {
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondStatus("/downloads/sequoia-0.1.1.jar", 404, "missing", "text/plain");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksumValue() + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Download failed with status 404", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyReleaseFailsWhenChecksumDownloadReturnsHttpError(@TempDir Path gameDir) throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondStatus("/downloads/sequoia-0.1.1.jar.sha256", 500, "broken", "text/plain");
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                RuntimeException error = assertThrows(
+                        RuntimeException.class,
+                        () -> manager.applyRelease(
+                                release(
+                                        "v0.1.1",
+                                        server.uri("/downloads/sequoia-0.1.1.jar"),
+                                        server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                                false));
+
+                assertEquals("Download failed with status 500", UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    @Test
+    void applyPendingUpdateOnWindowsStagesPendingInstallRegistersHookAndStopsWhenRequested(@TempDir Path gameDir)
+            throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+        String checksum = sha256(jarBytes);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksum + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-current.jar"), "packaged");
+            seedPendingRelease(
+                    manager,
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")));
+
+            manager.applyPendingUpdate(true);
+
+            assertTrue(Files.exists(gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.pending")));
+            assertFalse(Files.exists(gameDir.resolve("mods").resolve("sequoia-0.1.1.jar")));
+            assertEquals("Downloaded v0.1.1. It will install on exit.", manager.getStatusLine());
+            assertTrue(manager.notifications.contains("Downloaded v0.1.1. It will install when Minecraft closes."));
+            assertEquals(1, manager.stopRequests.get());
+            assertEquals(1, manager.shutdownHooks.size());
+
+            manager.applyPendingUpdate(false);
+            assertTrue(manager.notifications.contains("No pending update available."));
+        }
+    }
+
+    @Test
+    void applyReleaseOnWindowsRegistersShutdownHookOnlyOnce(@TempDir Path gameDir) throws Exception {
+        byte[] jarOne = "jar-one".getBytes(StandardCharsets.UTF_8);
+        byte[] jarTwo = "jar-two".getBytes(StandardCharsets.UTF_8);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarOne, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", sha256(jarOne) + "  sequoia-0.1.1.jar\n", "text/plain");
+            server.respondBytes("/downloads/sequoia-0.1.2.jar", jarTwo, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.2.jar.sha256", sha256(jarTwo) + "  sequoia-0.1.2.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-current.jar"), "packaged");
+
+            manager.applyRelease(
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                    false);
+            manager.applyRelease(
+                    release("v0.1.2", server.uri("/downloads/sequoia-0.1.2.jar"), server.uri("/downloads/sequoia-0.1.2.jar.sha256")),
+                    false);
+
+            assertEquals(1, manager.shutdownHooks.size());
+        }
+    }
+
+    @Test
+    void applyPendingInstallOnShutdownMovesPendingJarAndDeletesStaleSequoiaJars(@TempDir Path gameDir)
+            throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+        String checksum = sha256(jarBytes);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksum + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-current.jar"), "packaged");
+            manager.applyRelease(
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                    false);
+
+            Path modsDir = gameDir.resolve("mods");
+            Files.writeString(modsDir.resolve("sequoia-0.0.9.jar"), "stale");
+            Files.writeString(modsDir.resolve("othermod.jar"), "keep");
+
+            manager.windows = false;
+            manager.applyPendingInstallOnShutdown();
+
+            Path finalJar = modsDir.resolve("sequoia-0.1.1.jar");
+            assertTrue(Files.exists(finalJar));
+            assertArrayEquals(jarBytes, Files.readAllBytes(finalJar));
+            assertFalse(Files.exists(gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.pending")));
+            assertFalse(Files.exists(modsDir.resolve("sequoia-0.0.9.jar")));
+            assertTrue(Files.exists(modsDir.resolve("othermod.jar")));
+        }
+    }
+
+    @Test
+    void applyPendingInstallOnShutdownLaunchesWindowsHelper(@TempDir Path gameDir) throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+        String checksum = sha256(jarBytes);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksum + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-current.jar"), "packaged jar");
+            manager.javaExecutable = "java-test";
+            manager.applyRelease(
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                    false);
+
+            manager.applyPendingInstallOnShutdown();
+
+            assertEquals(1, manager.helperLaunches.size());
+            HelperLaunch launch = manager.helperLaunches.getFirst();
+            assertEquals("java-test", launch.javaExecutable());
+            assertEquals(gameDir.resolve("mods"), launch.modsDir());
+            assertEquals(gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.pending"), launch.pendingJar());
+            assertEquals(gameDir.resolve("mods").resolve("sequoia-0.1.1.jar"), launch.finalJar());
+            assertEquals(gameDir.resolve("updates").resolve("seq-update-helper.jar"), launch.helperJar());
+            assertArrayEquals(
+                    Files.readAllBytes(manager.currentModJarPath),
+                    Files.readAllBytes(gameDir.resolve("updates").resolve("seq-update-helper.jar")));
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void applyPendingInstallOnShutdownRunsRealWindowsHelperProcess(@TempDir Path gameDir) throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+        String checksum = sha256(jarBytes);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksum + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            manager.useRealHelperLaunch = true;
+            manager.currentModJarPath = gameDir.resolve("seq-current.jar");
+            writeUpdateApplierJar(manager.currentModJarPath);
+
+            manager.applyRelease(
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                    false);
+
+            manager.applyPendingInstallOnShutdown();
+
+            Path finalJar = gameDir.resolve("mods").resolve("sequoia-0.1.1.jar");
+            Path pendingJar = gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.pending");
+            Path helperJar = gameDir.resolve("updates").resolve("seq-update-helper.jar");
+
+            awaitCondition(
+                    () -> Files.exists(finalJar) && !Files.exists(pendingJar) && !Files.exists(helperJar),
+                    20,
+                    "Timed out waiting for the Windows helper process to finish.");
+
+            assertEquals(1, manager.helperLaunches.size());
+            assertArrayEquals(jarBytes, Files.readAllBytes(finalJar));
+        }
+    }
+
+    private static void assertFetchFailure(Path gameDir, String responseBody, String expectedMessage) throws Exception {
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondJson("/releases/latest", responseBody);
+
+            try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                TestableUpdateManager manager = newHttpManager(executor, server.uri("/releases/latest"), gameDir);
+
+                CompletionException error =
+                        assertThrows(CompletionException.class, () -> manager.fetchLatestRelease().join());
+
+                assertEquals(expectedMessage, UpdateManager.rootCauseMessage(error));
+            }
+        }
+    }
+
+    private static void seedPendingRelease(TestableUpdateManager manager, UpdateManager.ReleaseCandidate release) {
+        manager.installedVersion = "v0.1.0";
+        manager.enqueueFetchResult(CompletableFuture.completedFuture(release));
+        manager.checkForUpdatesManually();
+        assertEquals(1, manager.prompts.size());
+    }
+
+    private static String checksumValue() {
+        return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    }
+
+    private static UpdateManager.ReleaseCandidate release(String tagName) {
+        String version = tagName.substring(1);
+        String jarName = "sequoia-" + version + ".jar";
+        return new UpdateManager.ReleaseCandidate(
+                tagName,
+                "https://example.invalid/releases/" + tagName,
+                new UpdateManager.ReleaseAsset(jarName, "https://example.invalid/downloads/" + jarName),
+                new UpdateManager.ReleaseAsset(jarName + ".sha256", "https://example.invalid/downloads/" + jarName + ".sha256"));
+    }
+
+    private static UpdateManager.ReleaseCandidate release(String tagName, URI jarUrl, URI checksumUrl) {
+        return release(tagName, jarUrl, checksumUrl, null);
+    }
+
+    private static UpdateManager.ReleaseCandidate release(
+            String tagName, URI jarUrl, URI checksumUrl, String embeddedChecksum) {
+        String jarName = fileName(jarUrl);
+        return new UpdateManager.ReleaseCandidate(
+                tagName,
+                "https://example.invalid/releases/" + tagName,
+                new UpdateManager.ReleaseAsset(jarName, jarUrl.toString(), embeddedChecksum),
+                new UpdateManager.ReleaseAsset(jarName + ".sha256", checksumUrl.toString()));
+    }
+
+    private static String fileName(URI uri) {
+        String path = uri.getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    private static void writeUpdateApplierJar(Path jarFile) throws IOException {
+        Files.createDirectories(Objects.requireNonNull(jarFile.getParent()));
+        try (InputStream classBytes = Objects.requireNonNull(
+                        UpdateApplier.class.getResourceAsStream("UpdateApplier.class"),
+                        "Missing UpdateApplier class bytes");
+                JarOutputStream output = new JarOutputStream(Files.newOutputStream(jarFile))) {
+            output.putNextEntry(new JarEntry("org/sequoia/seq/update/UpdateApplier.class"));
+            classBytes.transferTo(output);
+            output.closeEntry();
+        }
+    }
+
+    private static void awaitCondition(BooleanSupplier condition, int timeoutSeconds, String message)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(condition.getAsBoolean(), message);
     }
 
     private static String sha256(byte[] bytes) throws Exception {
@@ -289,16 +852,63 @@ class UpdateManagerTest {
         return HexFormat.of().formatHex(digest.digest());
     }
 
+    private static TestableUpdateManager newHttpManager(ExecutorService executor, URI latestReleaseApi, Path gameDir) {
+        HttpClient httpClient = HttpClient.newBuilder().executor(executor).build();
+        return new TestableUpdateManager(httpClient, executor, latestReleaseApi, gameDir);
+    }
+
+    private static TestableUpdateManager newManager(ExecutorService executor, URI latestReleaseApi, Path gameDir) {
+        return new TestableUpdateManager(HttpClient.newHttpClient(), executor, latestReleaseApi, gameDir);
+    }
+
+    private static TestableUpdateManager newDirectManager(Path gameDir) {
+        DirectExecutorService executor = new DirectExecutorService();
+        return new TestableUpdateManager(HttpClient.newHttpClient(), executor, UNUSED_RELEASES_API, gameDir);
+    }
+
+    private record PromptCall(String installedVersion, UpdateManager.ReleaseCandidate candidate) {}
+
+    private record HelperLaunch(
+            String javaExecutable, Path helperJar, Path modsDir, Path currentJar, Path pendingJar, Path finalJar) {}
+
     private static final class TestableUpdateManager extends UpdateManager {
         private final Path gameDir;
-        private final boolean windows;
-        private final List<String> notifications = new ArrayList<>();
+        private final Queue<CompletableFuture<ReleaseCandidate>> fetchResults = new ConcurrentLinkedQueue<>();
+        private final List<String> notifications = new CopyOnWriteArrayList<>();
+        private final List<String> clickableNotifications = new CopyOnWriteArrayList<>();
+        private final List<PromptCall> prompts = new CopyOnWriteArrayList<>();
+        private final List<Thread> shutdownHooks = new CopyOnWriteArrayList<>();
+        private final List<HelperLaunch> helperLaunches = new CopyOnWriteArrayList<>();
+        private final AtomicInteger fetchCalls = new AtomicInteger();
+        private final AtomicInteger stopRequests = new AtomicInteger();
+        private final AtomicInteger browserOpenCount = new AtomicInteger();
+
+        private volatile String installedVersion = "v0.1.0";
+        private volatile boolean windows;
+        private volatile boolean browserShouldFail;
+        private volatile boolean skipRealApply;
+        private volatile RuntimeException applyFailure;
+        private volatile CountDownLatch applyStarted;
+        private volatile CountDownLatch allowApplyToFinish;
+        private volatile Path currentModJarPath;
+        private volatile String javaExecutable;
+        private volatile boolean useRealHelperLaunch;
 
         private TestableUpdateManager(
-                HttpClient httpClient, ExecutorService executor, URI latestReleaseApi, Path gameDir, boolean windows) {
+                HttpClient httpClient, ExecutorService executor, URI latestReleaseApi, Path gameDir) {
             super(httpClient, executor, new Gson(), latestReleaseApi);
             this.gameDir = gameDir;
-            this.windows = windows;
+        }
+
+        void enqueueFetchResult(CompletableFuture<ReleaseCandidate> result) {
+            fetchResults.add(result);
+        }
+
+        @Override
+        CompletableFuture<ReleaseCandidate> fetchLatestRelease() {
+            fetchCalls.incrementAndGet();
+            CompletableFuture<ReleaseCandidate> result = fetchResults.poll();
+            return result != null ? result : super.fetchLatestRelease();
         }
 
         @Override
@@ -307,15 +917,24 @@ class UpdateManagerTest {
         }
 
         @Override
+        String resolveInstalledVersion() {
+            return installedVersion;
+        }
+
+        @Override
         boolean isWindows() {
             return windows;
         }
 
         @Override
-        void showUpdatePrompt(String installedVersion, ReleaseCandidate candidate) {}
+        void showUpdatePrompt(String installedVersion, ReleaseCandidate candidate) {
+            prompts.add(new PromptCall(installedVersion, candidate));
+        }
 
         @Override
-        void requestMinecraftStop() {}
+        void requestMinecraftStop() {
+            stopRequests.incrementAndGet();
+        }
 
         @Override
         void sendNotification(String message) {
@@ -324,7 +943,98 @@ class UpdateManagerTest {
 
         @Override
         void sendClickableNotification(String text, String url) {
-            notifications.add(text + " -> " + url);
+            clickableNotifications.add(text + " -> " + url);
+        }
+
+        @Override
+        void openBrowser(String url) throws Exception {
+            browserOpenCount.incrementAndGet();
+            if (browserShouldFail) {
+                throw new IOException("Browser unavailable");
+            }
+        }
+
+        @Override
+        void addShutdownHook(Thread thread) {
+            shutdownHooks.add(thread);
+        }
+
+        @Override
+        Path resolveCurrentModJarPath() {
+            return currentModJarPath != null ? currentModJarPath : super.resolveCurrentModJarPath();
+        }
+
+        @Override
+        String resolveJavaExecutable() {
+            return javaExecutable != null ? javaExecutable : super.resolveJavaExecutable();
+        }
+
+        @Override
+        void launchUpdateHelperProcess(
+                String javaExe, Path helperJar, Path modsDir, Path currentJar, Path pendingJar, Path finalJar)
+                throws IOException {
+            helperLaunches.add(new HelperLaunch(javaExe, helperJar, modsDir, currentJar, pendingJar, finalJar));
+            if (useRealHelperLaunch) {
+                super.launchUpdateHelperProcess(javaExe, helperJar, modsDir, currentJar, pendingJar, finalJar);
+            }
+        }
+
+        @Override
+        void applyRelease(ReleaseCandidate release, boolean exitAfterInstall) {
+            CountDownLatch started = applyStarted;
+            if (started != null) {
+                started.countDown();
+            }
+            CountDownLatch gate = allowApplyToFinish;
+            if (gate != null) {
+                try {
+                    gate.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+            if (applyFailure != null) {
+                throw applyFailure;
+            }
+            if (!skipRealApply) {
+                super.applyRelease(release, exitAfterInstall);
+            }
+        }
+    }
+
+    private static final class DirectExecutorService extends AbstractExecutorService {
+        private volatile boolean shutdown;
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
         }
     }
 
@@ -345,11 +1055,15 @@ class UpdateManagerTest {
         }
 
         void respondText(String path, String body, String contentType) {
-            respondBytes(path, body.getBytes(StandardCharsets.UTF_8), contentType);
+            respondBytes(path, body.getBytes(StandardCharsets.UTF_8), 200, contentType);
         }
 
         void respondBytes(String path, byte[] body, String contentType) {
-            server.createContext(path, exchange -> writeResponse(exchange, body, contentType));
+            respondBytes(path, body, 200, contentType);
+        }
+
+        void respondStatus(String path, int status, String body, String contentType) {
+            respondBytes(path, body.getBytes(StandardCharsets.UTF_8), status, contentType);
         }
 
         void redirect(String path, String location) {
@@ -361,10 +1075,23 @@ class UpdateManagerTest {
             });
         }
 
-        private void writeResponse(HttpExchange exchange, byte[] body, String contentType) throws IOException {
+        void redirectWithoutLocation(String path) {
+            server.createContext(path, exchange -> {
+                try (exchange) {
+                    exchange.sendResponseHeaders(302, -1);
+                }
+            });
+        }
+
+        private void respondBytes(String path, byte[] body, int status, String contentType) {
+            server.createContext(path, exchange -> writeResponse(exchange, body, status, contentType));
+        }
+
+        private void writeResponse(HttpExchange exchange, byte[] body, int status, String contentType)
+                throws IOException {
             try (exchange) {
                 exchange.getResponseHeaders().add("Content-Type", contentType);
-                exchange.sendResponseHeaders(200, body.length);
+                exchange.sendResponseHeaders(status, body.length);
                 try (OutputStream output = exchange.getResponseBody()) {
                     output.write(body);
                 }


### PR DESCRIPTION
## Summary
- expand updater coverage across release parsing, state transitions, install failure paths, and Windows-specific update behavior
- add a Windows CI job that runs the updater test suite on a real Windows runner
- add a Windows-only integration test that exercises the real helper process launch path and ignore generated compressed logs

## Testing
- ./gradlew test --tests org.sequoia.seq.update.UpdateManagerTest --tests org.sequoia.seq.update.UpdateApplierTest
- ./gradlew test