### PR TITLE
fix(updater): harden windows auto-update replacement flow

### DIFF
--- a/src/main/java/org/sequoia/seq/update/UpdateApplier.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateApplier.java
@@ -1,9 +1,18 @@
 package org.sequoia.seq.update;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -13,6 +22,7 @@ import java.util.stream.Stream;
 public final class UpdateApplier {
     private static final int DEFAULT_RETRY_ATTEMPTS = 40;
     private static final long DEFAULT_RETRY_DELAY_MILLIS = 1500;
+    private static final Consumer<String> DEFAULT_LOGGER = message -> System.err.println("[SeqUpdater] " + message);
 
     private UpdateApplier() {
     }
@@ -39,56 +49,312 @@ public final class UpdateApplier {
             Path helperJar,
             int retryAttempts,
             long retryDelayMillis) {
-        boolean installed = applyWithRetries(modsDir, currentJar, pendingJar, finalJar, retryAttempts, retryDelayMillis);
+        run(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                helperJar,
+                retryAttempts,
+                retryDelayMillis,
+                Files::exists,
+                path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                (source, destination) -> {
+                    try {
+                        Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                directory -> {
+                    try (Stream<Path> stream = Files.list(directory)) {
+                        return stream.toList();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                UpdateApplier::sleep,
+                DEFAULT_LOGGER);
+    }
+
+    static void run(
+            Path modsDir,
+            Path currentJar,
+            Path pendingJar,
+            Path finalJar,
+            Path helperJar,
+            int retryAttempts,
+            long retryDelayMillis,
+            Predicate<Path> exists,
+            Consumer<Path> deleteIfExists,
+            BiConsumer<Path, Path> move,
+            Function<Path, List<Path>> list,
+            LongConsumer sleeper,
+            Consumer<String> logger) {
+        boolean installed = applyWithRetries(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                retryAttempts,
+                retryDelayMillis,
+                exists,
+                deleteIfExists,
+                move,
+                list,
+                sleeper,
+                logger);
         if (installed) {
-            deleteQuietly(pendingJar);
+            deleteQuietly(pendingJar, deleteIfExists);
         }
-        cleanupHelperJar(helperJar);
+        cleanupHelperJar(helperJar, exists, deleteIfExists, logger);
     }
 
     static boolean applyWithRetries(
             Path modsDir, Path currentJar, Path pendingJar, Path finalJar, int retryAttempts, long retryDelayMillis) {
+        return applyWithRetries(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                retryAttempts,
+                retryDelayMillis,
+                Files::exists,
+                path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                (source, destination) -> {
+                    try {
+                        Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                directory -> {
+                    try (Stream<Path> stream = Files.list(directory)) {
+                        return stream.toList();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                UpdateApplier::sleep,
+                DEFAULT_LOGGER);
+    }
+
+    static boolean applyWithRetries(
+            Path modsDir,
+            Path currentJar,
+            Path pendingJar,
+            Path finalJar,
+            int retryAttempts,
+            long retryDelayMillis,
+            Predicate<Path> exists,
+            Consumer<Path> deleteIfExists,
+            BiConsumer<Path, Path> move,
+            Function<Path, List<Path>> list,
+            LongConsumer sleeper,
+            Consumer<String> logger) {
+        Exception lastFailure = null;
+
         for (int attempt = 0; attempt < retryAttempts; attempt++) {
             try {
-                deleteReplacedJar(currentJar, finalJar);
-                Files.move(pendingJar, finalJar, StandardCopyOption.REPLACE_EXISTING);
-                deleteStaleSequoiaJars(modsDir, finalJar);
+                applyInstallAttempt(modsDir, currentJar, pendingJar, finalJar, exists, deleteIfExists, move, list);
                 return true;
-            } catch (Exception ignored) {
-                sleep(retryDelayMillis);
+            } catch (Exception e) {
+                lastFailure = e;
+                logger.accept("Update install attempt " + (attempt + 1) + "/" + retryAttempts
+                        + " failed: " + failureMessage(e));
+                if (attempt + 1 < retryAttempts) {
+                    sleeper.accept(retryDelayMillis);
+                }
             }
+        }
+
+        if (lastFailure != null) {
+            logger.accept(
+                    "Windows update helper gave up after " + retryAttempts + " attempts: " + failureMessage(lastFailure));
         }
         return false;
     }
 
-    private static void deleteReplacedJar(Path currentJar, Path finalJar) throws Exception {
+    private static void applyInstallAttempt(
+            Path modsDir,
+            Path currentJar,
+            Path pendingJar,
+            Path finalJar,
+            Predicate<Path> exists,
+            Consumer<Path> deleteIfExists,
+            BiConsumer<Path, Path> move,
+            Function<Path, List<Path>> list)
+            throws IOException {
+        Path backupJar = backupJarPath(currentJar);
+        stageCurrentJarForReplacement(currentJar, pendingJar, finalJar, backupJar, exists, move);
+        try {
+            movePendingJarIntoPlace(pendingJar, finalJar, currentJar, backupJar, exists, move);
+        } catch (IOException e) {
+            restoreCurrentJarIfNeeded(currentJar, finalJar, backupJar, exists, move);
+            throw e;
+        }
+        deleteQuietly(backupJar, deleteIfExists);
+        deleteStaleSequoiaJars(modsDir, finalJar, deleteIfExists, list);
+    }
+
+    private static void stageCurrentJarForReplacement(
+            Path currentJar,
+            Path pendingJar,
+            Path finalJar,
+            Path backupJar,
+            Predicate<Path> exists,
+            BiConsumer<Path, Path> move)
+            throws IOException {
         if (currentJar.equals(finalJar)) {
             return;
         }
-        Files.deleteIfExists(currentJar);
+
+        if (exists.test(backupJar) || !exists.test(currentJar)) {
+            return;
+        }
+
+        if (!exists.test(pendingJar) && !exists.test(finalJar)) {
+            throw new IOException("Pending update jar missing; keeping existing installed jar.");
+        }
+
+        movePath(currentJar, backupJar, move);
     }
 
-    private static void deleteStaleSequoiaJars(Path modsDir, Path finalJar) {
-        try (Stream<Path> stream = Files.list(modsDir)) {
-            stream.filter(path -> path.getFileName().toString().startsWith("sequoia-"))
-                    .filter(path -> path.getFileName().toString().endsWith(".jar"))
-                    .filter(path -> !path.equals(finalJar))
-                    .forEach(UpdateApplier::deleteQuietly);
-        } catch (Exception ignored) {
+    private static void movePendingJarIntoPlace(
+            Path pendingJar,
+            Path finalJar,
+            Path currentJar,
+            Path backupJar,
+            Predicate<Path> exists,
+            BiConsumer<Path, Path> move)
+            throws IOException {
+        if (exists.test(pendingJar)) {
+            movePath(pendingJar, finalJar, move);
+            return;
+        }
+        if (exists.test(finalJar)) {
+            return;
+        }
+        if (exists.test(backupJar)) {
+            throw new IOException("Pending update jar missing; restoring previous jar.");
+        }
+        if (!currentJar.equals(finalJar) && exists.test(currentJar)) {
+            throw new IOException("Pending update jar missing; keeping existing installed jar.");
+        }
+        throw new IOException("Pending update jar disappeared before install completed.");
+    }
+
+    private static void restoreCurrentJarIfNeeded(
+            Path currentJar, Path finalJar, Path backupJar, Predicate<Path> exists, BiConsumer<Path, Path> move)
+            throws IOException {
+        if (currentJar.equals(finalJar)) {
+            return;
+        }
+        if (!exists.test(backupJar) || exists.test(currentJar) || exists.test(finalJar)) {
+            return;
+        }
+        movePath(backupJar, currentJar, move);
+    }
+
+    private static Path backupJarPath(Path currentJar) {
+        return currentJar.resolveSibling(currentJar.getFileName().toString() + ".previous");
+    }
+
+    private static void deleteStaleSequoiaJars(
+            Path modsDir, Path finalJar, Consumer<Path> deleteIfExists, Function<Path, List<Path>> list)
+            throws IOException {
+        for (Path path : listStaleSequoiaJars(modsDir, finalJar, list)) {
+            try {
+                deletePath(path, deleteIfExists);
+            } catch (IOException ignored) {
+                // The remaining-files check below turns transient delete failures into retries.
+            }
+        }
+
+        List<Path> remaining = listStaleSequoiaJars(modsDir, finalJar, list);
+        if (!remaining.isEmpty()) {
+            throw new IOException("Failed to delete stale Sequoia jars: " + formatPaths(remaining));
         }
     }
 
-    private static void deleteQuietly(Path path) {
+    private static List<Path> listStaleSequoiaJars(Path modsDir, Path finalJar, Function<Path, List<Path>> list)
+            throws IOException {
+        List<Path> staleJars = new ArrayList<>();
+        for (Path path : listPaths(modsDir, list)) {
+            String fileName = path.getFileName().toString();
+            if (!fileName.startsWith("sequoia-") || !fileName.endsWith(".jar")) {
+                continue;
+            }
+            if (path.equals(finalJar)) {
+                continue;
+            }
+            staleJars.add(path);
+        }
+        return staleJars;
+    }
+
+    private static String formatPaths(List<Path> paths) {
+        return paths.stream()
+                .map(path -> path.getFileName().toString())
+                .sorted()
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("unknown");
+    }
+
+    private static String failureMessage(Exception exception) {
+        String message = exception.getMessage();
+        return message == null || message.isBlank() ? exception.getClass().getSimpleName() : message;
+    }
+
+    private static void deleteQuietly(Path path, Consumer<Path> deleteIfExists) {
         try {
-            Files.deleteIfExists(path);
+            deletePath(path, deleteIfExists);
         } catch (Exception ignored) {
         }
     }
 
-    private static void cleanupHelperJar(Path helperJar) {
-        deleteQuietly(helperJar);
-        if (Files.exists(helperJar) && isWindows()) {
+    private static void cleanupHelperJar(
+            Path helperJar, Predicate<Path> exists, Consumer<Path> deleteIfExists, Consumer<String> logger) {
+        deleteQuietly(helperJar, deleteIfExists);
+        if (exists.test(helperJar) && isWindows()) {
+            logger.accept("Scheduling delayed deletion for helper jar " + helperJar.getFileName());
             scheduleWindowsDelete(helperJar);
+        }
+    }
+
+    private static void deletePath(Path path, Consumer<Path> deleteIfExists) throws IOException {
+        try {
+            deleteIfExists.accept(path);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static void movePath(Path source, Path destination, BiConsumer<Path, Path> move) throws IOException {
+        try {
+            move.accept(source, destination);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static List<Path> listPaths(Path directory, Function<Path, List<Path>> list) throws IOException {
+        try {
+            return list.apply(directory);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 

--- a/src/main/java/org/sequoia/seq/update/UpdateManager.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateManager.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModOrigin;
 import net.minecraft.client.Minecraft;
 import org.sequoia.seq.accessors.NotificationAccessor;
 import org.sequoia.seq.client.SeqClient;
@@ -306,7 +308,7 @@ public class UpdateManager implements NotificationAccessor {
             }
 
             if (isWindows()) {
-                Path currentJar = resolveCurrentModJarPath();
+                Path currentJar = resolveInstalledModJarPath();
                 moveAtomically(tempJar, pendingJar);
                 pendingInstall = new PendingInstall(pendingJar, finalJar, modsDir, release.tagName(), currentJar);
                 registerShutdownHookIfNeeded();
@@ -431,6 +433,33 @@ public class UpdateManager implements NotificationAccessor {
                         finalJar.toString(),
                         helperJar.toString())
                 .start();
+    }
+
+    Path resolveInstalledModJarPath() {
+        try {
+            return FabricLoader.getInstance()
+                    .getModContainer(MOD_ID)
+                    .map(this::resolveInstalledModJarPath)
+                    .orElseGet(this::resolveCurrentModJarPath);
+        } catch (Exception e) {
+            SeqClient.LOGGER.warn("Falling back to runtime updater jar path for installed mod resolution", e);
+            return resolveCurrentModJarPath();
+        }
+    }
+
+    private Path resolveInstalledModJarPath(ModContainer container) {
+        ModOrigin origin = container.getOrigin();
+        if (origin.getKind() != ModOrigin.Kind.PATH) {
+            throw new IllegalStateException("Fabric Loader mod origin was " + origin.getKind() + ", expected PATH.");
+        }
+
+        for (Path path : origin.getPaths()) {
+            if (Files.isRegularFile(path) && path.getFileName().toString().endsWith(".jar")) {
+                return path.toAbsolutePath().normalize();
+            }
+        }
+
+        throw new IllegalStateException("Fabric Loader mod origin did not expose an installed jar path.");
     }
 
     Path resolveCurrentModJarPath() {

--- a/src/main/java/org/sequoia/seq/update/UpdateManager.java
+++ b/src/main/java/org/sequoia/seq/update/UpdateManager.java
@@ -309,8 +309,10 @@ public class UpdateManager implements NotificationAccessor {
 
             if (isWindows()) {
                 Path currentJar = resolveInstalledModJarPath();
+                Path helperSourceJar = resolveWindowsHelperSourceJarPath(currentJar);
                 moveAtomically(tempJar, pendingJar);
-                pendingInstall = new PendingInstall(pendingJar, finalJar, modsDir, release.tagName(), currentJar);
+                pendingInstall =
+                        new PendingInstall(pendingJar, finalJar, modsDir, release.tagName(), currentJar, helperSourceJar);
                 registerShutdownHookIfNeeded();
                 pendingRelease = null;
                 statusLine = "Downloaded " + release.tagName() + ". It will install on exit.";
@@ -401,7 +403,7 @@ public class UpdateManager implements NotificationAccessor {
                 throw new IllegalStateException("Missing updates directory for pending install.");
             }
 
-            Path sourceJar = resolveCurrentModJarPath();
+            Path sourceJar = install.helperSourceJar();
             Path helperJar = updatesDir.resolve("seq-update-helper.jar");
             Files.copy(sourceJar, helperJar, StandardCopyOption.REPLACE_EXISTING);
 
@@ -433,6 +435,16 @@ public class UpdateManager implements NotificationAccessor {
                         finalJar.toString(),
                         helperJar.toString())
                 .start();
+    }
+
+    Path resolveWindowsHelperSourceJarPath(Path installedJar) {
+        try {
+            return resolveCurrentModJarPath();
+        } catch (Exception e) {
+            SeqClient.LOGGER.warn(
+                    "Falling back to installed mod jar for Windows helper source resolution", e);
+            return installedJar;
+        }
     }
 
     Path resolveInstalledModJarPath() {
@@ -701,5 +713,6 @@ public class UpdateManager implements NotificationAccessor {
         }
     }
 
-    record PendingInstall(Path pendingJar, Path finalJar, Path modsDir, String tagName, Path currentJar) {}
+    record PendingInstall(
+            Path pendingJar, Path finalJar, Path modsDir, String tagName, Path currentJar, Path helperSourceJar) {}
 }

--- a/src/test/java/org/sequoia/seq/update/UpdateApplierTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateApplierTest.java
@@ -3,9 +3,17 @@ package org.sequoia.seq.update;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -118,5 +126,194 @@ class UpdateApplierTest {
         assertFalse(Files.exists(finalJar));
         assertTrue(Files.exists(pendingJar));
         assertFalse(Files.exists(helperJar));
+    }
+
+    @Test
+    void runRetriesUntilStaleJarDeletionSucceeds(@TempDir Path tempDir) throws Exception {
+        Path modsDir = tempDir.resolve("mods");
+        Path updatesDir = tempDir.resolve("updates");
+        Files.createDirectories(modsDir);
+        Files.createDirectories(updatesDir);
+
+        Path currentJar = modsDir.resolve("sequoia-0.0.1.jar");
+        Path staleJar = modsDir.resolve("sequoia-0.0.0.jar");
+        Path finalJar = modsDir.resolve("sequoia-0.0.2.jar");
+        Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
+        Path helperJar = updatesDir.resolve("seq-update-helper.jar");
+
+        Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
+        Files.writeString(staleJar, "stale", StandardCharsets.UTF_8);
+        byte[] pendingBytes = "pending".getBytes(StandardCharsets.UTF_8);
+        Files.write(pendingJar, pendingBytes);
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+
+        FlakyDeleteFileOps fileOps = new FlakyDeleteFileOps(staleJar);
+        List<String> logs = new ArrayList<>();
+
+        UpdateApplier.run(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                helperJar,
+                3,
+                0,
+                Files::exists,
+                deleteWithIo(fileOps::deleteIfExists),
+                moveWithIo(Files::move),
+                listWithIo(),
+                ignored -> {},
+                logs::add);
+
+        assertTrue(Files.exists(finalJar));
+        assertArrayEquals(pendingBytes, Files.readAllBytes(finalJar));
+        assertFalse(Files.exists(currentJar));
+        assertFalse(Files.exists(staleJar));
+        assertFalse(Files.exists(pendingJar));
+        assertFalse(Files.exists(helperJar));
+        assertTrue(logs.stream().anyMatch(message -> message.contains("sequoia-0.0.0.jar")));
+    }
+
+    @Test
+    void runKeepsCurrentJarWhenPendingJarIsMissing(@TempDir Path tempDir) throws Exception {
+        Path modsDir = tempDir.resolve("mods");
+        Path updatesDir = tempDir.resolve("updates");
+        Files.createDirectories(modsDir);
+        Files.createDirectories(updatesDir);
+
+        Path currentJar = modsDir.resolve("sequoia-0.0.1.jar");
+        Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
+        Path helperJar = updatesDir.resolve("seq-update-helper.jar");
+        Path finalJar = modsDir.resolve("sequoia-0.0.2.jar");
+
+        Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+
+        List<String> logs = new ArrayList<>();
+
+        UpdateApplier.run(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                helperJar,
+                2,
+                0,
+                Files::exists,
+                deleteWithIo(Files::deleteIfExists),
+                moveWithIo(Files::move),
+                listWithIo(),
+                ignored -> {},
+                logs::add);
+
+        assertTrue(Files.exists(currentJar));
+        assertFalse(Files.exists(finalJar));
+        assertFalse(Files.exists(pendingJar));
+        assertFalse(Files.exists(helperJar));
+        assertTrue(logs.stream().anyMatch(message -> message.contains("keeping existing installed jar")));
+    }
+
+    @Test
+    void runDoesNotPublishNewJarWhenCurrentJarCannotBeMoved(@TempDir Path tempDir) throws Exception {
+        Path modsDir = tempDir.resolve("mods");
+        Path updatesDir = tempDir.resolve("updates");
+        Files.createDirectories(modsDir);
+        Files.createDirectories(updatesDir);
+
+        Path currentJar = modsDir.resolve("sequoia-0.0.1.jar");
+        Path finalJar = modsDir.resolve("sequoia-0.0.2.jar");
+        Path pendingJar = updatesDir.resolve("sequoia-0.0.2.jar.pending");
+        Path helperJar = updatesDir.resolve("seq-update-helper.jar");
+        Path backupJar = currentJar.resolveSibling(currentJar.getFileName().toString() + ".previous");
+
+        Files.writeString(currentJar, "current", StandardCharsets.UTF_8);
+        Files.writeString(pendingJar, "pending", StandardCharsets.UTF_8);
+        Files.writeString(helperJar, "helper", StandardCharsets.UTF_8);
+
+        List<String> logs = new ArrayList<>();
+
+        UpdateApplier.run(
+                modsDir,
+                currentJar,
+                pendingJar,
+                finalJar,
+                helperJar,
+                2,
+                0,
+                Files::exists,
+                deleteWithIo(Files::deleteIfExists),
+                moveWithIo((source, destination) -> {
+                    if (source.equals(currentJar) && destination.equals(backupJar)) {
+                        throw new IOException("simulated current jar lock");
+                    }
+                    Files.move(source, destination);
+                }),
+                listWithIo(),
+                ignored -> {},
+                logs::add);
+
+        assertTrue(Files.exists(currentJar));
+        assertTrue(Files.exists(pendingJar));
+        assertFalse(Files.exists(finalJar));
+        assertFalse(Files.exists(backupJar));
+        assertFalse(Files.exists(helperJar));
+        assertTrue(logs.stream().anyMatch(message -> message.contains("simulated current jar lock")));
+    }
+
+    private static Consumer<Path> deleteWithIo(IoConsumer<Path> consumer) {
+        return path -> {
+            try {
+                consumer.accept(path);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    private static BiConsumer<Path, Path> moveWithIo(IoBiConsumer<Path, Path> consumer) {
+        return (source, destination) -> {
+            try {
+                consumer.accept(source, destination);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    private static Function<Path, List<Path>> listWithIo() {
+        return directory -> {
+            try (var stream = Files.list(directory)) {
+                return stream.toList();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    @FunctionalInterface
+    private interface IoConsumer<T> {
+        void accept(T value) throws IOException;
+    }
+
+    @FunctionalInterface
+    private interface IoBiConsumer<T, U> {
+        void accept(T left, U right) throws IOException;
+    }
+
+    private static final class FlakyDeleteFileOps {
+        private final Path flakyPath;
+        private boolean failedOnce;
+
+        private FlakyDeleteFileOps(Path flakyPath) {
+            this.flakyPath = flakyPath;
+        }
+
+        public void deleteIfExists(Path path) throws IOException {
+            if (!failedOnce && path.equals(flakyPath)) {
+                failedOnce = true;
+                throw new IOException("simulated transient lock for " + path.getFileName());
+            }
+            Files.deleteIfExists(path);
+        }
     }
 }

--- a/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
@@ -736,6 +736,38 @@ class UpdateManagerTest {
     }
 
     @Test
+    void applyPendingInstallOnShutdownFallsBackToInstalledJarWhenRuntimeJarResolutionFails(@TempDir Path gameDir)
+            throws Exception {
+        byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
+        String checksum = sha256(jarBytes);
+
+        try (TestHttpServer server = new TestHttpServer()) {
+            server.respondBytes("/downloads/sequoia-0.1.1.jar", jarBytes, "application/java-archive");
+            server.respondText("/downloads/sequoia-0.1.1.jar.sha256", checksum + "  sequoia-0.1.1.jar\n", "text/plain");
+
+            TestableUpdateManager manager = newDirectManager(gameDir);
+            manager.windows = true;
+            Files.createDirectories(gameDir.resolve("mods"));
+            manager.installedModJarPath = Files.writeString(
+                    gameDir.resolve("mods").resolve("sequoia-0.1.0.jar"), "installed mod jar");
+            manager.currentModJarPathFailure = new IllegalStateException("runtime jar unavailable");
+            manager.javaExecutable = "java-test";
+            manager.applyRelease(
+                    release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
+                    false);
+
+            manager.applyPendingInstallOnShutdown();
+
+            assertEquals(1, manager.helperLaunches.size());
+            HelperLaunch launch = manager.helperLaunches.getFirst();
+            assertEquals(manager.installedModJarPath, launch.currentJar());
+            assertArrayEquals(
+                    Files.readAllBytes(manager.installedModJarPath),
+                    Files.readAllBytes(gameDir.resolve("updates").resolve("seq-update-helper.jar")));
+        }
+    }
+
+    @Test
     @EnabledOnOs(OS.WINDOWS)
     void applyPendingInstallOnShutdownRunsRealWindowsHelperProcess(@TempDir Path gameDir) throws Exception {
         byte[] jarBytes = "fake-jar-binary".getBytes(StandardCharsets.UTF_8);
@@ -899,6 +931,7 @@ class UpdateManagerTest {
         private volatile CountDownLatch applyStarted;
         private volatile CountDownLatch allowApplyToFinish;
         private volatile Path currentModJarPath;
+        private volatile RuntimeException currentModJarPathFailure;
         private volatile Path installedModJarPath;
         private volatile String javaExecutable;
         private volatile boolean useRealHelperLaunch;
@@ -970,6 +1003,9 @@ class UpdateManagerTest {
 
         @Override
         Path resolveCurrentModJarPath() {
+            if (currentModJarPathFailure != null) {
+                throw currentModJarPathFailure;
+            }
             return currentModJarPath != null ? currentModJarPath : super.resolveCurrentModJarPath();
         }
 

--- a/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
+++ b/src/test/java/org/sequoia/seq/update/UpdateManagerTest.java
@@ -710,7 +710,10 @@ class UpdateManagerTest {
 
             TestableUpdateManager manager = newDirectManager(gameDir);
             manager.windows = true;
-            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-current.jar"), "packaged jar");
+            manager.currentModJarPath = Files.writeString(gameDir.resolve("seq-runtime.jar"), "packaged helper source");
+            Files.createDirectories(gameDir.resolve("mods"));
+            manager.installedModJarPath = Files.writeString(
+                    gameDir.resolve("mods").resolve("sequoia-0.1.0.jar"), "installed mod jar");
             manager.javaExecutable = "java-test";
             manager.applyRelease(
                     release("v0.1.1", server.uri("/downloads/sequoia-0.1.1.jar"), server.uri("/downloads/sequoia-0.1.1.jar.sha256")),
@@ -722,6 +725,7 @@ class UpdateManagerTest {
             HelperLaunch launch = manager.helperLaunches.getFirst();
             assertEquals("java-test", launch.javaExecutable());
             assertEquals(gameDir.resolve("mods"), launch.modsDir());
+            assertEquals(manager.installedModJarPath, launch.currentJar());
             assertEquals(gameDir.resolve("updates").resolve("sequoia-0.1.1.jar.pending"), launch.pendingJar());
             assertEquals(gameDir.resolve("mods").resolve("sequoia-0.1.1.jar"), launch.finalJar());
             assertEquals(gameDir.resolve("updates").resolve("seq-update-helper.jar"), launch.helperJar());
@@ -895,6 +899,7 @@ class UpdateManagerTest {
         private volatile CountDownLatch applyStarted;
         private volatile CountDownLatch allowApplyToFinish;
         private volatile Path currentModJarPath;
+        private volatile Path installedModJarPath;
         private volatile String javaExecutable;
         private volatile boolean useRealHelperLaunch;
 
@@ -966,6 +971,17 @@ class UpdateManagerTest {
         @Override
         Path resolveCurrentModJarPath() {
             return currentModJarPath != null ? currentModJarPath : super.resolveCurrentModJarPath();
+        }
+
+        @Override
+        Path resolveInstalledModJarPath() {
+            if (installedModJarPath != null) {
+                return installedModJarPath;
+            }
+            if (currentModJarPath != null) {
+                return currentModJarPath;
+            }
+            return super.resolveInstalledModJarPath();
         }
 
         @Override


### PR DESCRIPTION
## Summary
- resolve the installed Sequoia jar from Fabric Loader origin for the Windows helper path
- make the Windows helper replacement flow failure-safe so a missing or locked jar does not uninstall the mod or leave duplicate active jars
- extend updater tests to cover helper launch, rollback, and duplicate-jar regressions

## Testing
- ./gradlew test