### PR TITLE
Smooth Radiance visualiser startup load

### DIFF
--- a/src/main/java/org/sequoia/seq/radiance/PingManager.java
+++ b/src/main/java/org/sequoia/seq/radiance/PingManager.java
@@ -7,7 +7,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.phys.Vec3;
 
 public final class PingManager {
-    private static final int WORLD_RING_SPAWN_INTERVAL_TICKS = 12;
+    private static final int WORLD_RING_REFRESH_COOLDOWN_TICKS = 16;
     private static final List<WorldPing> ACTIVE_PINGS = new ArrayList<>();
 
     private PingManager() {}
@@ -32,11 +32,12 @@ public final class PingManager {
                             Math.max(ping.radius(), radius),
                             Math.max(ping.ticksLeft(), durationTicks),
                             ping.showCircle() || showCircle,
-                            ping.particleSpawnCooldownTicks()));
+                            ping.showCircle() ? ping.ringPhase() : 0,
+                            ping.showCircle() ? ping.ringRefreshCooldownTicks() : 0));
             return;
         }
 
-        ACTIVE_PINGS.add(new WorldPing(id, pos, radius, durationTicks, showCircle, 0));
+        ACTIVE_PINGS.add(new WorldPing(id, pos, radius, durationTicks, showCircle, 0, 0));
     }
 
     public static void updatePingRadius(UUID id, float radius) {
@@ -47,7 +48,6 @@ public final class PingManager {
                 continue;
             }
 
-            int particleSpawnCooldownTicks = ping.showCircle() ? ping.particleSpawnCooldownTicks() : 0;
             ACTIVE_PINGS.set(
                     i,
                     new WorldPing(
@@ -56,7 +56,8 @@ public final class PingManager {
                             Math.max(ping.radius(), radius),
                             ping.ticksLeft(),
                             true,
-                            particleSpawnCooldownTicks));
+                            ping.showCircle() ? ping.ringPhase() : 0,
+                            ping.showCircle() ? ping.ringRefreshCooldownTicks() : 0));
             return;
         }
     }
@@ -70,7 +71,7 @@ public final class PingManager {
         List<WorldPing> remainingPings = new ArrayList<>();
 
         for (WorldPing ping : ACTIVE_PINGS) {
-            int particleSpawnCooldownTicks = tickParticleSpawnCooldown(client, ping);
+            RingState ringState = tickRing(client, ping);
 
             int ticksLeft = ping.ticksLeft() - 1;
             if (ticksLeft > 0) {
@@ -81,7 +82,8 @@ public final class PingManager {
                                 ping.radius(),
                                 ticksLeft,
                                 ping.showCircle(),
-                                particleSpawnCooldownTicks));
+                                ringState.phase,
+                                ringState.cooldownTicks));
             }
         }
 
@@ -93,16 +95,22 @@ public final class PingManager {
         return List.copyOf(ACTIVE_PINGS);
     }
 
-    private static int tickParticleSpawnCooldown(Minecraft client, WorldPing ping) {
+    private static RingState tickRing(Minecraft client, WorldPing ping) {
         if (!ping.showCircle()) {
-            return ping.particleSpawnCooldownTicks();
+            return new RingState(ping.ringPhase(), ping.ringRefreshCooldownTicks());
         }
 
-        if (ping.particleSpawnCooldownTicks() <= 0) {
-            PingRenderer.renderWorld(client, ping);
-            return WORLD_RING_SPAWN_INTERVAL_TICKS - 1;
+        if (ping.ringRefreshCooldownTicks() > 0) {
+            return new RingState(0, ping.ringRefreshCooldownTicks() - 1);
         }
 
-        return ping.particleSpawnCooldownTicks() - 1;
+        boolean completedRing = PingRenderer.renderWorld(client, ping);
+        if (completedRing) {
+            return new RingState(0, WORLD_RING_REFRESH_COOLDOWN_TICKS);
+        }
+
+        return new RingState(ping.ringPhase() + 1, 0);
     }
+
+    private record RingState(int phase, int cooldownTicks) {}
 }

--- a/src/main/java/org/sequoia/seq/radiance/PingRenderer.java
+++ b/src/main/java/org/sequoia/seq/radiance/PingRenderer.java
@@ -10,6 +10,7 @@ import org.joml.Vector3fc;
 
 public final class PingRenderer {
     private static final int WORLD_RING_SEGMENTS = 32;
+    private static final int WORLD_RING_PARTICLES_PER_TICK = 2;
 
     private PingRenderer() {}
 
@@ -43,22 +44,26 @@ public final class PingRenderer {
         }
     }
 
-    public static void renderWorld(Minecraft client, WorldPing ping) {
+    public static boolean renderWorld(Minecraft client, WorldPing ping) {
         if (client.level == null || !ping.showCircle()) {
-            return;
+            return false;
         }
 
         Vec3 pos = ping.pos();
         double radius = ping.radius();
         double y = pos.y + 0.05;
 
-        for (int i = 0; i < WORLD_RING_SEGMENTS; i++) {
-            double angle = (Math.PI * 2.0 * i) / WORLD_RING_SEGMENTS;
+        int startSegment = Math.floorMod(ping.ringPhase() * WORLD_RING_PARTICLES_PER_TICK, WORLD_RING_SEGMENTS);
+        for (int i = 0; i < WORLD_RING_PARTICLES_PER_TICK; i++) {
+            int segment = (startSegment + i) % WORLD_RING_SEGMENTS;
+            double angle = (Math.PI * 2.0 * segment) / WORLD_RING_SEGMENTS;
             double x = pos.x + Math.cos(angle) * radius;
             double z = pos.z + Math.sin(angle) * radius;
 
             client.level.addAlwaysVisibleParticle(ParticleTypes.END_ROD, x, y, z, 0.0, 0.0, 0.0);
         }
+
+        return startSegment + WORLD_RING_PARTICLES_PER_TICK >= WORLD_RING_SEGMENTS;
     }
 
     private static ScreenPos worldToScreen(Minecraft client, Vec3 worldPos) {

--- a/src/main/java/org/sequoia/seq/radiance/RadianceCheckerClient.java
+++ b/src/main/java/org/sequoia/seq/radiance/RadianceCheckerClient.java
@@ -21,6 +21,7 @@ public final class RadianceCheckerClient {
                             @Override
                             public void onResourceManagerReload(ResourceManager manager) {
                                 ResourcePackModelScanner.reset();
+                                ResourcePackModelScanner.scan(manager);
                             }
                         });
 

--- a/src/main/java/org/sequoia/seq/radiance/ResourcePackModelScanner.java
+++ b/src/main/java/org/sequoia/seq/radiance/ResourcePackModelScanner.java
@@ -89,7 +89,13 @@ public final class ResourcePackModelScanner {
             return true;
         }
 
-        ResourceManager rm = client.getResourceManager();
+        return scan(client.getResourceManager());
+    }
+
+    public static boolean scan(ResourceManager rm) {
+        if (scanned) {
+            return true;
+        }
         if (rm == null) {
             return false;
         }

--- a/src/main/java/org/sequoia/seq/radiance/WorldPing.java
+++ b/src/main/java/org/sequoia/seq/radiance/WorldPing.java
@@ -4,4 +4,4 @@ import java.util.UUID;
 import net.minecraft.world.phys.Vec3;
 
 public record WorldPing(
-        UUID id, Vec3 pos, float radius, int ticksLeft, boolean showCircle, int particleSpawnCooldownTicks) {}
+        UUID id, Vec3 pos, float radius, int ticksLeft, boolean showCircle, int ringPhase, int ringRefreshCooldownTicks) {}


### PR DESCRIPTION
Changes:
Ring particles now spawn in smaller chunks. (to reduce lag which it did)
Average ring particle output reduced to about 1.0 particle/tick. (to reduce lag which it did)
Resource-pack model scan is triggered during resource reload so first in-game Radiance should not pay that scan cost. (need to test if this works / ruduces lag)

gone for the weekend so cant fully help :hurtme: